### PR TITLE
Python2.5 compatibility -- do not use relative import *

### DIFF
--- a/nipy/algorithms/registration/__init__.py
+++ b/nipy/algorithms/registration/__init__.py
@@ -1,12 +1,12 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-from .resample import * 
-from .histogram_registration import * 
-from .affine import * 
-from .groupwise_registration import * 
+from resample import *
+from histogram_registration import *
+from affine import *
+from groupwise_registration import *
 
 from numpy.testing import Tester
 
 test = Tester().test
-bench = Tester().bench 
+bench = Tester().bench
 

--- a/nipy/neurospin/group/tests/test_mixed_effects.py
+++ b/nipy/neurospin/group/tests/test_mixed_effects.py
@@ -1,7 +1,7 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
-from ..mixed_effects import * 
+from nipy.neurospin.group.mixed_effects import *
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal


### PR DESCRIPTION
not sure really if you would like to adopt this patch... you might if you have anyone using nipy with python2.5 (i.e. on clusters with stable environment).  At least it doesn't do harm afaik ;-)
