### PR TITLE
RF - remove troublesome parametric decorator

### DIFF
--- a/nipy/labs/group/tests/test_spatial_relaxation_onesample.py
+++ b/nipy/labs/group/tests/test_spatial_relaxation_onesample.py
@@ -4,13 +4,12 @@ import numpy as np
 
 from ..spatial_relaxation_onesample import multivariate_stat
 
-from ....testing import (parametric, dec, assert_true, 
-                         assert_equal, assert_almost_equal)
-                          
+from ....testing import (dec, assert_true, assert_equal, assert_almost_equal)
+
 verbose = False
 
-def make_data(n=10, dim=np.array([20,20,20]), r=5, amplitude=10, noise=1, 
-            jitter=None, prng=np.random):
+def make_data(n=10, dim=np.array([20,20,20]), r=5, amplitude=10, noise=1,
+              jitter=None, prng=np.random):
     if np.isscalar(dim):
         dim = np.array([dim,dim,dim])
     XYZvol = np.zeros((dim),int)
@@ -40,39 +39,37 @@ def make_data(n=10, dim=np.array([20,20,20]), r=5, amplitude=10, noise=1,
     return data, XYZ, XYZvol, vardata, signal
 
 
-@parametric
 def test_evaluate_exact():
     # without mfx nor spatial relaxation
     prng = np.random.RandomState(10)
-    data, XYZ, XYZvol, vardata, signal = make_data(n=20, 
-            dim=np.array([20,20,20]), r=3, amplitude=5, noise=0, 
+    data, XYZ, XYZvol, vardata, signal = make_data(n=20,
+            dim=np.array([20,20,20]), r=3, amplitude=5, noise=0,
             jitter=0, prng=prng)
     p = len(signal)
     XYZvol *= 0
     XYZvol[list(XYZ)] = np.arange(p)
     P = multivariate_stat(data)
     P.init_hidden_variables()
-    P.evaluate(nsimu=100, burnin=100, J=[XYZvol[5, 5, 5]], 
+    P.evaluate(nsimu=100, burnin=100, J=[XYZvol[5, 5, 5]],
                compute_post_mean=True, verbose=verbose)
     P.log_likelihood_values = P.compute_log_region_likelihood()
     # Verify code consistency
     Q = multivariate_stat(data, vardata*0, XYZ, std=0, sigma=5)
     Q.init_hidden_variables()
-    Q.evaluate(nsimu=100, burnin=100, J = [XYZvol[5,5,5]], 
-               compute_post_mean=True, update_spatial=False, 
+    Q.evaluate(nsimu=100, burnin=100, J = [XYZvol[5,5,5]],
+               compute_post_mean=True, update_spatial=False,
                verbose=verbose)
     Q.log_likelihood_values = Q.compute_log_region_likelihood()
-    yield assert_almost_equal(P.mean_m.mean(),
+    assert_almost_equal(P.mean_m.mean(),
                               Q.mean_m.mean(),
                               int(np.log10(P.nsimu))-1)
-    yield assert_almost_equal(Q.log_likelihood_values.sum(),
+    assert_almost_equal(Q.log_likelihood_values.sum(),
                               P.log_likelihood_values.sum(), 0)
 
 
-@parametric
 def test_model_selection_exact():
     prng = np.random.RandomState(10)
-    data, XYZ, XYZvol, vardata, signal = make_data(n=30, dim=20, r=3, 
+    data, XYZ, XYZvol, vardata, signal = make_data(n=30, dim=20, r=3,
                 amplitude=1, noise=0, jitter=0, prng=prng)
     labels = (signal > 0).astype(int)
     P1 = multivariate_stat(data, labels=labels)
@@ -83,43 +80,41 @@ def test_model_selection_exact():
     #v, m_mean, m_var = P1.v.copy(), P1.m_mean.copy(), P1.m_var.copy()
     Post1 = P1.compute_log_posterior(nsimu=1e2, burnin=1e2, verbose=verbose)
     M1 = L1 + Prior1[:-1] - Post1[:-1]
-    yield assert_almost_equal(M1.mean(), 
-                              P1.compute_marginal_likelihood().mean(), 0)
+    assert_almost_equal(M1.mean(), P1.compute_marginal_likelihood().mean(), 0)
     P0 = multivariate_stat(data, labels=labels)
     P0.network *= 0
     P0.init_hidden_variables()
     P0.evaluate(nsimu=100, burnin=100, verbose=verbose)
     L0 = P0.compute_log_region_likelihood()
     Prior0 = P0.compute_log_prior()
-    Post0 = P0.compute_log_posterior(nsimu=1e2, burnin=1e2, 
+    Post0 = P0.compute_log_posterior(nsimu=1e2, burnin=1e2,
                                      verbose=verbose)
     M0 = L0 + Prior0[:-1] - Post0[:-1]
-    yield assert_almost_equal(M0.mean(), 
-                              P0.compute_marginal_likelihood().mean(), 0)
-    yield assert_true(M1[1] > M0[1])
-    yield assert_true(M1[0] < M0[0])
-    
+    assert_almost_equal(M0.mean(), P0.compute_marginal_likelihood().mean(), 0)
+    assert_true(M1[1] > M0[1])
+    assert_true(M1[0] < M0[0])
+
 
 @dec.slow # test takes around 7 minutes on my (MB) Mac laptop
-@parametric
 def test_model_selection_mfx_spatial_rand_walk():
     prng = np.random.RandomState(10)
-    data, XYZ, XYZvol, vardata, signal = make_data(n=20, 
-                                dim=np.array([1,20,20]), 
-                                r=3, amplitude=3, noise=1,
-                                jitter=0.5, prng=prng)
+    data, XYZ, XYZvol, vardata, signal = make_data(
+        n=20,
+        dim=np.array([1,20,20]),
+        r=3, amplitude=3, noise=1,
+        jitter=0.5, prng=prng)
     labels = (signal > 0).astype(int)
     P = multivariate_stat(data, vardata, XYZ, std=0.5, sigma=5, labels=labels)
     P.network[:] = 0
     P.init_hidden_variables()
-    P.evaluate(nsimu=100, burnin=100, verbose=verbose, 
-                proposal='rand_walk', proposal_std=0.5)
+    P.evaluate(nsimu=100, burnin=100, verbose=verbose,
+               proposal='rand_walk', proposal_std=0.5)
     L00 = P.compute_log_region_likelihood()
     # Test simulated annealing procedure
-    P.estimate_displacements_SA(nsimu=100, c=0.99, 
-        proposal_std=P.proposal_std, verbose=verbose)
+    P.estimate_displacements_SA(nsimu=100, c=0.99,
+                                proposal_std=P.proposal_std, verbose=verbose)
     L0 = P.compute_log_region_likelihood()
-    yield assert_true(L0.sum() > L00.sum())
+    assert_true(L0.sum() > L00.sum())
     #Prior0 = P.compute_log_prior()
     #Post0 = P.compute_log_posterior(nsimu=1e2, burnin=1e2, verbose=verbose)
     #M0 = L0 + Prior0[:-1] - Post0[:-1]
@@ -128,26 +123,26 @@ def test_model_selection_mfx_spatial_rand_walk():
     P.network[1] = 1
     #P.init_hidden_variables(init_spatial=False)
     P.init_hidden_variables(init_spatial=False)
-    P.evaluate(nsimu=100, burnin=100, verbose=verbose, 
-                update_spatial=False, proposal_std=P.proposal_std)
+    P.evaluate(nsimu=100, burnin=100, verbose=verbose,
+               update_spatial=False, proposal_std=P.proposal_std)
     #L1 = P.compute_log_region_likelihood()
     #Prior1 = P.compute_log_prior()
     #Post1 = P.compute_log_posterior(nsimu=1e2, burnin=1e2, verbose=verbose)
     #M1 = L1 + Prior1[:-1] - Post1[:-1]
     M1 = P.compute_marginal_likelihood(update_spatial=True)
     #yield assert_almost_equal(0.1*M1.sum(), 0.1*P.compute_marginal_likelihood(verbose=verbose).sum(), 0)
-    yield assert_true(M1 > M0)
+    assert_true(M1 > M0)
 
 
-@parametric
 def test_evaluate_mfx_spatial():
     prng = np.random.RandomState(10)
-    data, XYZ, XYZvol, vardata, signal = make_data(n=20, 
-                dim=10, r=3, amplitude=5, noise=1, jitter=1,
-                prng=prng)
+    data, XYZ, XYZvol, vardata, signal = make_data(
+        n=20,
+        dim=10, r=3, amplitude=5, noise=1, jitter=1,
+        prng=prng)
     P = multivariate_stat(data, vardata, XYZ, std=1, sigma=3)
     P.init_hidden_variables()
-    P.evaluate(nsimu=5, burnin=5, 
+    P.evaluate(nsimu=5, burnin=5,
                J=[P.D.XYZ_vol[10, 10, 10]],
                verbose=verbose, mode='mcmc')
     # Test log_likelihood computation
@@ -156,7 +151,7 @@ def test_evaluate_mfx_spatial():
     m_mean = P.m_mean.copy()
     L1 = P.compute_log_region_likelihood_slow(v, m_mean, m_var)
     L2 = P.compute_log_region_likelihood(v, m_mean, m_var)
-    yield assert_almost_equal(-L1.sum(), L2.sum()*2, 2)
+    assert_almost_equal(-L1.sum(), L2.sum()*2, 2)
     # Test posterior density computation
     #Prior = P.compute_log_prior(v, m_mean, m_var)
     #Post = P.compute_log_posterior(v, m_mean, m_var, nsimu=10, 
@@ -165,8 +160,9 @@ def test_evaluate_mfx_spatial():
 
 def test_update_labels():
     prng = np.random.RandomState(10)
-    data, XYZ, XYZvol, vardata, signal = make_data(n=20, dim=20, r=3, 
-                    amplitude=5, noise=1, jitter=1, prng=prng)
+    data, XYZ, XYZvol, vardata, signal = make_data(
+        n=20, dim=20, r=3,
+        amplitude=5, noise=1, jitter=1, prng=prng)
     P = multivariate_stat(data, vardata, XYZ)
     P.init_hidden_variables()
     p = P.data.shape[1]
@@ -175,4 +171,3 @@ def test_update_labels():
     P.labels_prior_mask = np.arange(p)
     P.update_labels()
     assert_equal(max(abs(P.labels - np.zeros(p, int))), 0)
-


### PR DESCRIPTION
Removed parametric decorator from tests, and adapt tests accordingly.

Specifically, the parametric decorator was stopping the 'slow' decorator
from working, and making the tests - very slow.

Took the opportunity to reformat the tests.
