### PR TITLE
BF - work around test error for 32 bit ndimage

### DIFF
--- a/nipy/labs/datasets/volumes/tests/test_volume_grid.py
+++ b/nipy/labs/datasets/volumes/tests/test_volume_grid.py
@@ -62,7 +62,7 @@ def test_trivial_grid():
                     transform=identity,
                     )
     x, y, z = np.random.random_integers(N, size=(3, 10)) - 1
-    data_ = img. values_in_world(x, y, z)
+    data_ = img.values_in_world(x, y, z)
     # Check that passing in arrays with different shapes raises an error
     yield np.testing.assert_raises, ValueError, \
         img.values_in_world, x, y, z[:-1]


### PR DESCRIPTION
scipy.ndimage did not accept the np.intp datatype for coordinate arrays,
but coincidentally, that is what np.random.random_integer seemed to
provide.  Upstream fix at:

https://github.com/scipy/scipy/pull/64
