### PR TITLE
RF - use relative imports, test functions

### DIFF
--- a/nipy/fixes/scipy/stats/models/tests/test_glm.py
+++ b/nipy/fixes/scipy/stats/models/tests/test_glm.py
@@ -5,32 +5,27 @@ Test functions for models.GLM
 """
 
 import numpy as np
-import numpy.random as R
-from numpy.testing import *
 
-import nipy.fixes.scipy.stats.models as S
-import nipy.fixes.scipy.stats.models.glm as models
+from .. import family
+from ..glm import Model as GLM
 
-W = R.standard_normal
+from nose.tools import assert_equal
 
-class TestRegression(TestCase):
-
-    def test_Logistic(self):
-        X = W((40,10))
-        Y = np.greater(W((40,)), 0)
-        family = S.family.Binomial()
-        cmodel = models(design=X, family=S.family.Binomial())
-        results = cmodel.fit(Y)
-        self.assertEquals(results.df_resid, 30)
-
-    def test_Logisticdegenerate(self):
-        X = W((40,10))
-        X[:,0] = X[:,1] + X[:,2]
-        Y = np.greater(W((40,)), 0)
-        family = S.family.Binomial()
-        cmodel = models(design=X, family=S.family.Binomial())
-        results = cmodel.fit(Y)
-        self.assertEquals(results.df_resid, 31)
+W = np.random.standard_normal
 
 
+def test_Logistic():
+    X = W((40,10))
+    Y = np.greater(W((40,)), 0)
+    cmodel = GLM(design=X, family=family.Binomial())
+    results = cmodel.fit(Y)
+    assert_equal(results.df_resid, 30)
 
+
+def test_Logisticdegenerate():
+    X = W((40,10))
+    X[:,0] = X[:,1] + X[:,2]
+    Y = np.greater(W((40,)), 0)
+    cmodel = GLM(design=X, family=family.Binomial())
+    results = cmodel.fit(Y)
+    assert_equal(results.df_resid, 31)

--- a/nipy/fixes/scipy/stats/models/tests/test_olsR.py
+++ b/nipy/fixes/scipy/stats/models/tests/test_olsR.py
@@ -1,10 +1,10 @@
 
 import numpy as np
-from nipy.fixes.scipy.stats.models.regression import OLSModel
+from ..regression import OLSModel
 import nipy.testing as niptest
 import scipy.stats
 
-from exampledata import x, y
+from .exampledata import x, y
 
 Rscript = '''
 d = read.table('data.csv', header=T, sep=' ')

--- a/nipy/fixes/scipy/stats/models/tests/test_regression.py
+++ b/nipy/fixes/scipy/stats/models/tests/test_regression.py
@@ -4,44 +4,44 @@
 Test functions for models.regression
 """
 
-from numpy.random import standard_normal
-from numpy.testing import *
+import numpy as np
 
-from nipy.fixes.scipy.stats.models.regression import OLSModel, ARModel
+from ..regression import OLSModel, ARModel
 
-W = standard_normal
+from nose.tools import assert_equal
 
-class TestRegression(TestCase):
-
-    def testOLS(self):
-        X = W((40,10))
-        Y = W((40,))
-        model = OLSModel(design=X)
-        results = model.fit(Y)
-        self.assertEquals(results.df_resid, 30)
-
-    def testAR(self):
-        X = W((40,10))
-        Y = W((40,))
-        model = ARModel(design=X, rho=0.4)
-        results = model.fit(Y)
-        self.assertEquals(results.df_resid, 30)
-
-    def testOLSdegenerate(self):
-        X = W((40,10))
-        X[:,0] = X[:,1] + X[:,2]
-        Y = W((40,))
-        model = OLSModel(design=X)
-        results = model.fit(Y)
-        self.assertEquals(results.df_resid, 31)
-
-    def testARdegenerate(self):
-        X = W((40,10))
-        X[:,0] = X[:,1] + X[:,2]
-        Y = W((40,))
-        model = ARModel(design=X, rho=0.9)
-        results = model.fit(Y)
-        self.assertEquals(results.df_resid, 31)
+W = np.random.standard_normal
 
 
+def test_OLS():
+    X = W((40,10))
+    Y = W((40,))
+    model = OLSModel(design=X)
+    results = model.fit(Y)
+    assert_equal(results.df_resid, 30)
 
+
+def test_AR():
+    X = W((40,10))
+    Y = W((40,))
+    model = ARModel(design=X, rho=0.4)
+    results = model.fit(Y)
+    assert_equal(results.df_resid, 30)
+
+
+def test_OLSdegenerate():
+    X = W((40,10))
+    X[:,0] = X[:,1] + X[:,2]
+    Y = W((40,))
+    model = OLSModel(design=X)
+    results = model.fit(Y)
+    assert_equal(results.df_resid, 31)
+
+
+def test_ARdegenerate():
+    X = W((40,10))
+    X[:,0] = X[:,1] + X[:,2]
+    Y = W((40,))
+    model = ARModel(design=X, rho=0.9)
+    results = model.fit(Y)
+    assert_equal(results.df_resid, 31)

--- a/nipy/fixes/scipy/stats/models/tests/test_utils.py
+++ b/nipy/fixes/scipy/stats/models/tests/test_utils.py
@@ -7,11 +7,11 @@ Test functions for models.utils
 import numpy as np
 import numpy.random as R
 
-from nipy.fixes.scipy.stats.models import utils
-from nipy.fixes.scipy.stats.models.utils import pos_recipr, recipr0
+from .. import utils
+from ..utils import pos_recipr, recipr0
 
-from numpy.testing import assert_equal, assert_array_equal, \
-    assert_array_almost_equal, TestCase
+from nose.tools import (assert_equal, assert_true, assert_raises)
+from numpy.testing import (assert_array_equal, assert_array_almost_equal)
 
 
 def test_pos_recipr():
@@ -31,7 +31,7 @@ def test_pos_recipr():
     yield assert_equal, pos_recipr(0), 0
     yield assert_equal, pos_recipr(2), 0.5
 
-    
+
 def test_recipr0():
     X = np.array([[2,1],[-4,0]])
     Y = recipr0(X)
@@ -43,43 +43,40 @@ def test_recipr0():
     yield assert_equal, recipr0(-1), -1
     yield assert_equal, recipr0(0), 0
     yield assert_equal, recipr0(2), 0.5
-    
-
-class TestUtils(TestCase):
-
-    def test_rank(self):
-        X = R.standard_normal((40,10))
-        self.assertEquals(utils.rank(X), 10)
-
-        X[:,0] = X[:,1] + X[:,2]
-        self.assertEquals(utils.rank(X), 9)
-
-    def test_fullrank(self):
-        X = R.standard_normal((40,10))
-        X[:,0] = X[:,1] + X[:,2]
-
-        Y = utils.fullrank(X)
-        self.assertEquals(Y.shape, (40,9))
-        self.assertEquals(utils.rank(Y), 9)
-
-        X[:,5] = X[:,3] + X[:,4]
-        Y = utils.fullrank(X)
-        self.assertEquals(Y.shape, (40,8))
-        self.assertEquals(utils.rank(Y), 8)
-
-    def test_StepFunction(self):
-        x = np.arange(20)
-        y = np.arange(20)
-        f = utils.StepFunction(x, y)
-        assert_array_almost_equal(f( np.array([[3.2,4.5],[24,-3.1]]) ), [[ 3, 4], [19, 0]])
-
-    def test_StepFunctionBadShape(self):
-        x = np.arange(20)
-        y = np.arange(21)
-        self.assertRaises(ValueError, utils.StepFunction, x, y)
-        x = np.zeros((2, 2))
-        y = np.zeros((2, 2))
-        self.assertRaises(ValueError, utils.StepFunction, x, y)
 
 
+def test_rank():
+    X = R.standard_normal((40,10))
+    assert_equal(utils.rank(X), 10)
+    X[:,0] = X[:,1] + X[:,2]
+    assert_equal(utils.rank(X), 9)
 
+
+def test_fullrank():
+    X = R.standard_normal((40,10))
+    X[:,0] = X[:,1] + X[:,2]
+
+    Y = utils.fullrank(X)
+    assert_equal(Y.shape, (40,9))
+    assert_equal(utils.rank(Y), 9)
+
+    X[:,5] = X[:,3] + X[:,4]
+    Y = utils.fullrank(X)
+    assert_equal(Y.shape, (40,8))
+    assert_equal(utils.rank(Y), 8)
+
+
+def test_StepFunction():
+    x = np.arange(20)
+    y = np.arange(20)
+    f = utils.StepFunction(x, y)
+    assert_array_almost_equal(f( np.array([[3.2,4.5],[24,-3.1]]) ), [[ 3, 4], [19, 0]])
+
+
+def test_StepFunctionBadShape():
+    x = np.arange(20)
+    y = np.arange(21)
+    assert_raises(ValueError, utils.StepFunction, x, y)
+    x = np.zeros((2, 2))
+    y = np.zeros((2, 2))
+    assert_raises(ValueError, utils.StepFunction, x, y)


### PR DESCRIPTION
Refactoring of tests to use relative imports, ready for move to
algorithms.statistics.
Removal of TestCase test classes in favor of test functions.
