### PR TITLE
RF - move apply_affine class to utils.affines

### DIFF
--- a/nipy/algorithms/registration/affine.py
+++ b/nipy/algorithms/registration/affine.py
@@ -6,6 +6,7 @@ import scipy.linalg as spl
 from nipy.externals.transforms3d.quaternions import mat2quat, quat2axangle
 
 from .transform import Transform
+from ..utils.affines import apply_affine
 
 # Defaults
 _radius = 100
@@ -119,31 +120,6 @@ def preconditioner(radius):
 
 def inverse_affine(affine):
     return spl.inv(affine)
-
-
-def apply_affine(aff, pts):
-    """ Apply affine `T` to points `pts`
-
-    Parameters
-    ----------
-    aff : (N, N) array-like
-        Homogenous affine, probably 4 by 4
-    pts : (P, N-1) array-like
-        Points, one point per row.  N-1 is probably 3.
-
-    Returns
-    -------
-    transformed_pts : (P, N-1) array
-        transformed points
-    """
-    # Apply N by N homogenous affine to P by N-1 array
-    pts = np.asarray(pts)
-    shape = pts.shape
-    pts = pts.reshape((-1, shape[-1]))
-    rzs = aff[:-1,:-1]
-    trans = aff[:-1,-1]
-    res = np.dot(pts, rzs.T) + trans[None,:]
-    return res.reshape(shape)
 
 
 def subgrid_affine(affine, slices):

--- a/nipy/algorithms/registration/grid_transform.py
+++ b/nipy/algorithms/registration/grid_transform.py
@@ -1,9 +1,11 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-from .affine import apply_affine, subgrid_affine, inverse_affine
 
 import numpy as np 
 from scipy.ndimage import gaussian_filter
+
+from ..utils.affines import apply_affine
+from .affine import subgrid_affine, inverse_affine
 
 
 class GridTransform(object): 

--- a/nipy/algorithms/registration/groupwise_registration.py
+++ b/nipy/algorithms/registration/groupwise_registration.py
@@ -1,6 +1,7 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-from .affine import Rigid, Similarity, Affine, apply_affine
+from ..utils.affines import apply_affine
+from .affine import Rigid, Similarity, Affine
 from ._cubic_spline import cspline_transform, cspline_sample3d, cspline_sample4d
 
 from nipy.core.image.affine_image import AffineImage

--- a/nipy/algorithms/registration/resample.py
+++ b/nipy/algorithms/registration/resample.py
@@ -1,7 +1,8 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
-from .affine import Affine, apply_affine
+from ..utils.affines import apply_affine
+from .affine import Affine
 from .grid_transform import GridTransform
 from ._cubic_spline import cspline_transform, cspline_sample3d, cspline_resample3d
 

--- a/nipy/algorithms/registration/tests/test_affine.py
+++ b/nipy/algorithms/registration/tests/test_affine.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from ..affine import (Affine, Affine2D, Rigid, Rigid2D,
                       Similarity, Similarity2D,
-                      rotation_mat2vec, apply_affine)
+                      rotation_mat2vec)
 
 from nose.tools import assert_true, assert_false
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -54,35 +54,6 @@ def test_rotation_mat2vec():
     assert_false(np.isnan(r).max())
 
 
-def validated_apply_affine(T, xyz):
-    # This was the original apply_affine implementation that we've stashed here
-    # to test against
-    xyz = np.asarray(xyz)
-    shape = xyz.shape[0:-1]
-    XYZ = np.dot(np.reshape(xyz, (np.prod(shape), 3)), T[0:3,0:3].T)
-    XYZ[:,0] += T[0,3]
-    XYZ[:,1] += T[1,3]
-    XYZ[:,2] += T[2,3]
-    XYZ = np.reshape(XYZ, shape+(3,))
-    return XYZ
-
-
-def test_apply_affine():
-    aff = np.diag([2, 3, 4, 1])
-    pts = np.random.uniform(size=(4,3))
-    assert_array_equal(apply_affine(aff, pts),
-                       pts * [[2, 3, 4]])
-    aff[:3,3] = [10, 11, 12]
-    assert_array_equal(apply_affine(aff, pts),
-                       pts * [[2, 3, 4]] + [[10, 11, 12]])
-    aff[:3,:] = np.random.normal(size=(3,4))
-    exp_res = np.concatenate((pts.T, np.ones((1,4))), axis=0)
-    exp_res = np.dot(aff, exp_res)[:3,:].T
-    assert_array_equal(apply_affine(aff, pts), exp_res)
-    # Check we get the same result as the previous implementation
-    assert_almost_equal(validated_apply_affine(aff, pts), apply_affine(aff, pts))
-
-
 def test_composed_affines():
     aff1 = np.diag([2, 3, 4, 1])
     aff2 = np.eye(4)
@@ -100,6 +71,7 @@ def test_composed_affines():
     comped_remixed = np.dot(aff2_remixed, aff1_remixed)
     assert_array_almost_equal(comped_remixed,
                               Affine(comped_remixed).as_affine())
+
 
 def test_affine_types():
     pts = np.random.normal(size=(10,3))

--- a/nipy/algorithms/registration/tests/test_chain_transforms.py
+++ b/nipy/algorithms/registration/tests/test_chain_transforms.py
@@ -25,7 +25,8 @@ import numpy as np
 import numpy.linalg as npl
 
 from ..chain_transform import ChainTransform
-from ..affine import Affine, apply_affine
+from ...utils.affines import apply_affine
+from ..affine import Affine
 
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal)

--- a/nipy/algorithms/utils/affines.py
+++ b/nipy/algorithms/utils/affines.py
@@ -1,0 +1,76 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+""" Utility routines for working with points and affine transforms
+"""
+
+import numpy as np
+
+
+def apply_affine(aff, pts):
+    """ Apply affine matrix `aff` to points `pts`
+
+    Returns result of application of `aff` to the *right* of `pts`.  The
+    coordinate dimension of `pts` should be the last.
+
+    For the 3D case, `aff` will be shape (4,4) and `pts` will have final axis
+    length 3 - maybe it will just be N by 3. The return value is the transformed
+    points, in this case::
+
+        res = np.dot(aff[:3,:3], pts.T) + aff[:3,3:4]
+        transformed_pts = res.T
+
+    Notice though, that this routine is more general, in that `aff` can have any
+    shape (N,N), and `pts` can have any shape, as long as the last dimension is
+    for the coordinates, and is therefore length N-1.
+
+    Parameters
+    ----------
+    aff : (N, N) array-like
+        Homogenous affine, for 3D points, will be 4 by 4. Contrary to first
+        appearance, the affine will be applied on the left of `pts`.
+    pts : (..., N-1) array-like
+        Points, where the last dimension contains the coordinates of each point.
+        For 3D, the last dimension will be length 3.
+
+    Returns
+    -------
+    transformed_pts : (..., N-1) array
+        transformed points
+
+    Examples
+    --------
+    >>> aff = np.array([[0,2,0,10],[3,0,0,11],[0,0,4,12],[0,0,0,1]])
+    >>> pts = np.array([[1,2,3],[2,3,4],[4,5,6],[6,7,8]])
+    >>> apply_affine(aff, pts)
+    array([[14, 14, 24],
+           [16, 17, 28],
+           [20, 23, 36],
+           [24, 29, 44]])
+
+    Just to show that in the simple 3D case, it is equivalent to:
+
+    >>> (np.dot(aff[:3,:3], pts.T) + aff[:3,3:4]).T
+    array([[14, 14, 24],
+           [16, 17, 28],
+           [20, 23, 36],
+           [24, 29, 44]])
+
+    But `pts` can be a more complicated shape:
+
+    >>> pts = pts.reshape((2,2,3))
+    >>> apply_affine(aff, pts)
+    array([[[14, 14, 24],
+            [16, 17, 28]],
+    <BLANKLINE>
+           [[20, 23, 36],
+            [24, 29, 44]]])
+    """
+    aff = np.asarray(aff)
+    pts = np.asarray(pts)
+    shape = pts.shape
+    pts = pts.reshape((-1, shape[-1]))
+    # rzs == rotations, zooms, shears
+    rzs = aff[:-1,:-1]
+    trans = aff[:-1,-1]
+    res = np.dot(pts, rzs.T) + trans[None,:]
+    return res.reshape(shape)

--- a/nipy/algorithms/utils/tests/test_affines.py
+++ b/nipy/algorithms/utils/tests/test_affines.py
@@ -1,0 +1,65 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+
+import numpy as np
+
+from ..affines import apply_affine
+
+from nose.tools import assert_equal
+from numpy.testing import assert_array_equal, assert_almost_equal
+
+
+def validated_apply_affine(T, xyz):
+    # This was the original apply_affine implementation that we've stashed here
+    # to test against
+    xyz = np.asarray(xyz)
+    shape = xyz.shape[0:-1]
+    XYZ = np.dot(np.reshape(xyz, (np.prod(shape), 3)), T[0:3,0:3].T)
+    XYZ[:,0] += T[0,3]
+    XYZ[:,1] += T[1,3]
+    XYZ[:,2] += T[2,3]
+    XYZ = np.reshape(XYZ, shape+(3,))
+    return XYZ
+
+
+def test_apply_affine():
+    rng = np.random.RandomState(20110903)
+    aff = np.diag([2, 3, 4, 1])
+    pts = rng.uniform(size=(4,3))
+    assert_array_equal(apply_affine(aff, pts),
+                       pts * [[2, 3, 4]])
+    aff[:3,3] = [10, 11, 12]
+    assert_array_equal(apply_affine(aff, pts),
+                       pts * [[2, 3, 4]] + [[10, 11, 12]])
+    aff[:3,:] = rng.normal(size=(3,4))
+    exp_res = np.concatenate((pts.T, np.ones((1,4))), axis=0)
+    exp_res = np.dot(aff, exp_res)[:3,:].T
+    assert_array_equal(apply_affine(aff, pts), exp_res)
+    # Check we get the same result as the previous implementation
+    assert_almost_equal(validated_apply_affine(aff, pts), apply_affine(aff, pts))
+    # Check that lists work for inputs
+    assert_array_equal(apply_affine(aff.tolist(), pts.tolist()), exp_res)
+    # Check that it's the same as a banal implementation in the simple case
+    aff = np.array([[0,2,0,10],[3,0,0,11],[0,0,4,12],[0,0,0,1]])
+    pts = np.array([[1,2,3],[2,3,4],[4,5,6],[6,7,8]])
+    exp_res = (np.dot(aff[:3,:3], pts.T) + aff[:3,3:4]).T
+    assert_array_equal(apply_affine(aff, pts), exp_res)
+    # That points can be reshaped and you'll get the same shape output
+    pts = pts.reshape((2,2,3))
+    exp_res = exp_res.reshape((2,2,3))
+    assert_array_equal(apply_affine(aff, pts), exp_res)
+    # That ND also works
+    for N in range(2,6):
+        aff = np.eye(N)
+        nd = N-1
+        aff[:nd,:nd] = rng.normal(size=(nd,nd))
+        pts = rng.normal(size=(2,3,nd))
+        res = apply_affine(aff, pts)
+        # crude apply
+        new_pts = np.ones((N,6))
+        new_pts[:-1,:] = np.rollaxis(pts, -1).reshape((nd,6))
+        exp_pts = np.dot(aff, new_pts)
+        exp_pts = np.rollaxis(exp_pts[:-1,:], 0, 2)
+        exp_res = exp_pts.reshape((2,3,nd))
+        assert_array_equal(res, exp_res)
+

--- a/nipy/labs/statistical_mapping.py
+++ b/nipy/labs/statistical_mapping.py
@@ -3,9 +3,9 @@
 import numpy as np
 import scipy.stats as sp_stats
 
-from nipy.algorithms.registration import apply_affine
-from nipy.algorithms.graph.field import field_from_graph_and_data
-from nipy.algorithms.graph.graph import wgraph_from_3d_grid
+from ..algorithms.utils.affines import apply_affine
+from ..algorithms.graph.field import field_from_graph_and_data
+from ..algorithms.graph.graph import wgraph_from_3d_grid
 from ..algorithms.statistics import empirical_pvalue
 from .glm import glm
 from .group.permutation_test import \


### PR DESCRIPTION
apply_affine is shared at least between the registration modules and the
statistical mapping labs module, and is useful elsewhere in the
codebase.

We've still got another apply_affine in the datasets/volumes alternative
image implementation.
