### PR TITLE
RF - deprecate image.header

### DIFF
--- a/nipy/core/image/image.py
+++ b/nipy/core/image/image.py
@@ -103,28 +103,25 @@ class Image(object):
     ###################################################################
 
     def _getheader(self):
-        # data loaded from a file should have a header
-        try:
-            return self._header
-        except AttributeError:
+        # data loaded from a file may have a header
+        warnings.warn("Please don't use ``img.header``; use"
+                      "``img.metadata['header'] instead",
+                      DeprecationWarning,
+                      stacklevel=2)
+        hdr = self.metadata.get('header')
+        if hdr is None:
             raise AttributeError('Image created from arrays '
                                  'may not have headers.')
+        return hdr
     def _setheader(self, header):
-        warnings.warn('Image.header may be deprecated if '
-                      'load_image returns an LPIImage')
-        self._header = header
+        warnings.warn("Please don't use ``img.header``; use"
+                      "``img.metadata['header'] instead",
+                      DeprecationWarning,
+                      stacklevel=2)
+        self.metadata['header'] = header
     _doc['header'] = \
-    """The file header dictionary for this image.  In order to update
-    the header, you must first make a copy of the header, set the
-    values you wish to change, then set the image header to the
-    updated header.
-
-    Example
-    -------
-    hdr = img.header
-    hdr['slice_duration'] = 0.200
-    hdr['descrip'] = 'My image registered with MNI152.'
-    img.header = hdr
+    """The file header structure for this image, if available.  This interface
+    will soon go away - you should use ``img.metadata['header'] instead.
     """
     header = property(_getheader, _setheader, doc=_doc['header'])
 

--- a/nipy/io/files.py
+++ b/nipy/io/files.py
@@ -54,12 +54,11 @@ def load(filename):
     """
     img = nib.load(filename)
     aff = img.get_affine()
-    shape = img.get_shape()
     hdr = img.get_header()
     # If the header implements it, get a list of names, one per axis,
     # and put this into the coordinate map.  In fact, no image format
     # implements this at the moment, so in practice, the following code
-    # is not currently called. 
+    # is not currently called.
     axis_renames = {}
     try:
         axis_names = hdr.axis_names
@@ -77,8 +76,8 @@ def load(filename):
     # affine_transform is a 3-d transform
     affine_transform3d, affine_transform = \
         affine_transform_from_array(aff, 'ijk', pixdim=zooms[3:])
-    img = Image(img.get_data(), affine_transform.renamed_domain(axis_renames))
-    img.header = hdr
+    img = Image(img.get_data(), affine_transform.renamed_domain(axis_renames),
+                metadata={'header': hdr})
     return img
 
 

--- a/nipy/io/tests/test_image_io.py
+++ b/nipy/io/tests/test_image_io.py
@@ -1,7 +1,5 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-import os
-import warnings
 
 import numpy as np
 
@@ -12,7 +10,7 @@ from nipy.core.api import fromarray
 
 from nipy.testing import (assert_true, assert_equal, assert_raises,
                           assert_array_equal, assert_array_almost_equal,
-                          assert_almost_equal, funcfile)
+                          assert_almost_equal, funcfile, anatfile)
 
 from nibabel.tmpdirs import InTemporaryDirectory
 
@@ -99,22 +97,18 @@ def test_scaling():
             assert_almost_equal(newdata, data)
 
 
-@if_templates
 def test_header_roundtrip():
-    img = load_template_img()
-    fd, name = mkstemp(suffix='.nii.gz')
-    tmpfile = open(name)
-    hdr = img.header
+    img = load_image(anatfile)
+    hdr = img.metadata['header']
     # Update some header values and make sure they're saved
     hdr['slice_duration'] = 0.200
     hdr['intent_p1'] = 2.0
     hdr['descrip'] = 'descrip for TestImage:test_header_roundtrip'
     hdr['slice_end'] = 12
-    img.header = hdr
     with InTemporaryDirectory():
         save_image(img, 'img.nii.gz')
         newimg = load_image('img.nii.gz')
-    newhdr = newimg.header
+    newhdr = newimg.metadata['header']
     assert_array_almost_equal(newhdr['slice_duration'],
                               hdr['slice_duration'])
     assert_equal(newhdr['intent_p1'], hdr['intent_p1'])
@@ -122,9 +116,8 @@ def test_header_roundtrip():
     assert_equal(newhdr['slice_end'], hdr['slice_end'])
 
 
-@if_templates
 def test_file_roundtrip():
-    img = load_template_img()
+    img = load_image(anatfile)
     data = img.get_data()
     with InTemporaryDirectory():
         save_image(img, 'img.nii.gz')


### PR DESCRIPTION
Move header into image.metadata dictionary.

I brought this up on the mailing list a week or so ago, no replies, so I assume this is OK.
