### PR TITLE
BF: Fixed the so-called recursivity bug.

### DIFF
--- a/nipy/labs/group/tests/test_permutation_test.py
+++ b/nipy/labs/group/tests/test_permutation_test.py
@@ -28,7 +28,7 @@ class test_permutation_test(unittest.TestCase):
         # rfx calibration
         P = pt.permutation_test_onesample(data, XYZ, ndraws=ndraws)
         c = [(P.random_Tvalues[P.ndraws*(0.95)],None), (
-                P.random_Tvalues[P.ndraws*(0.5)], 10)]
+                P.random_Tvalues[P.ndraws*(0.5)], 18.)]
         r = np.ones(data.shape[1],int)
         r[data.shape[1]/2:] *= 10
         #p_values, cluster_results, region_results = P.calibrate(nperms=100, clusters=c, regions=[r])


### PR DESCRIPTION
BF: Fixed the so-called recursivity bug. As far as i can understand, the test was wrong because it was assuming that supra-threshold clusters in a (10,10,10)-shaped box had necessarily a diameter smaller than 10, which yielded problems when this  was not the case. The recursive loop is in the graph code, butin the permutation code... which obviously needs to be rewritten
