### PR TITLE
BF: fixed flattening of numpy dtypes for looping in test_strides_from

### DIFF
--- a/nipy/utils/tests/test_arrays.py
+++ b/nipy/utils/tests/test_arrays.py
@@ -14,7 +14,7 @@ from nose.tools import assert_true, assert_equal, assert_raises
 def test_strides_from():
     for shape in ((3,), (2,3), (2,3,4), (5,4,3,2)):
         for order in 'FC':
-            for dtype in np.sum(np.sctypes.values()):
+            for dtype in sum(np.sctypes.values(), []):
                 if dtype is str:
                     dtype = 'S3'
                 elif dtype is unicode:


### PR DESCRIPTION
I am a bit confused though -- may be there was some higher vision of what the test should have done?
