### PR TITLE
relax comparison to assert_array_almost_equal in test_apply_affine

### DIFF
--- a/nipy/algorithms/utils/tests/test_affines.py
+++ b/nipy/algorithms/utils/tests/test_affines.py
@@ -6,7 +6,8 @@ import numpy as np
 from ..affines import apply_affine, append_diag
 
 from nose.tools import assert_equal, assert_raises
-from numpy.testing import assert_array_equal, assert_almost_equal
+from numpy.testing import assert_array_equal, assert_almost_equal, \
+     assert_array_almost_equal
 
 
 def validated_apply_affine(T, xyz):
@@ -61,7 +62,7 @@ def test_apply_affine():
         exp_pts = np.dot(aff, new_pts)
         exp_pts = np.rollaxis(exp_pts[:-1,:], 0, 2)
         exp_res = exp_pts.reshape((2,3,nd))
-        assert_array_equal(res, exp_res)
+        assert_array_almost_equal(res, exp_res)
 
 
 def test_append_diag():


### PR DESCRIPTION
otherwise leads to silly failure due to minuscule loss of precision
during operation:

AssertionError:
Arrays are not equal

(mismatch 16.6666666667%)
 x: array([[[-0.50688799, -1.66266008, -4.00463121],
        [ 3.34535676, -0.93336192,  0.81055908],
        [ 1.8903341 , -0.50335599, -3.35445869]],...
 y: array([[[-0.50688799, -1.66266008, -4.00463121],
        [ 3.34535676, -0.93336192,  0.81055908],
        [ 1.8903341 , -0.50335599, -3.35445869]],...

(Pdb) print x
[[[-0.50688799 -1.66266008 -4.00463121]
  [ 3.34535676 -0.93336192  0.81055908]
  [ 1.8903341  -0.50335599 -3.35445869]]

 [[ 0.65062492 -1.29969132 -2.77813354]
  [ 4.01248837  0.63213532 -0.52546691]
  [-6.76387776 -0.60131449  0.17963992]]]
(Pdb) print y
[[[-0.50688799 -1.66266008 -4.00463121]
  [ 3.34535676 -0.93336192  0.81055908]
  [ 1.8903341  -0.50335599 -3.35445869]]

 [[ 0.65062492 -1.29969132 -2.77813354]
  [ 4.01248837  0.63213532 -0.52546691]
  [-6.76387776 -0.60131449  0.17963992]]]
(Pdb) print x - y
[[[  0.00000000e+00   0.00000000e+00   0.00000000e+00]
  [  0.00000000e+00   0.00000000e+00   0.00000000e+00]
  [  2.22044605e-16   0.00000000e+00   0.00000000e+00]]

 [[ -1.11022302e-16   0.00000000e+00   0.00000000e+00]
  [ -8.88178420e-16   0.00000000e+00   0.00000000e+00]
  [  0.00000000e+00   0.00000000e+00   0.00000000e+00]]]
