### PR TITLE
Let's release 0.1.999 meanwhile

### DIFF
--- a/nipy/info.py
+++ b/nipy/info.py
@@ -8,8 +8,8 @@ docs.  In setup.py in particular, we exec this file, so it cannot import nipy
 # version
 _version_major = 0
 _version_minor = 1
-_version_micro = 999
-_version_extra = ''
+_version_micro = 9999
+_version_extra = '.dev'
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 __version__ = "%s.%s.%s%s" % (_version_major,


### PR DESCRIPTION
Debian packages are ready and built across nearly all debian/ubuntu releases, will be uploaded upon merge of this PL (and I can push upstream/0.1.999 tag):

```
nipy_0.1.999-1_amd64.build      OK      28:52.66 real, 1365.52 user, 175.03 sys, 2278208 out
nipy_0.1.999-1~nd60+1_i386.build        OK      19:38.24 real, 872.16 user, 170.03 sys, 1549472 out
nipy_0.1.999-1~nd60+1_amd64.build       OK      29:18.78 real, 1362.56 user, 200.50 sys, 1974504 out
nipy_0.1.999-1~nd70+1_i386.build        OK      19:28.28 real, 889.20 user, 187.66 sys, 1830360 out
nipy_0.1.999-1~nd70+1_amd64.build       OK      27:25.89 real, 1365.76 user, 209.99 sys, 2262808 out
nipy_0.1.999-1~nd+1_i386.build  OK      19:31.40 real, 892.79 user, 202.92 sys, 1844672 out
nipy_0.1.999-1~nd+1_amd64.build OK      27:11.82 real, 1354.59 user, 215.75 sys, 2277216 out
nipy_0.1.999-1~nd10.10+1_i386.build     OK      26:38.74 real, 717.30 user, 734.66 sys, 1147824 out
nipy_0.1.999-1~nd10.10+1_amd64.build    OK      33:50.81 real, 1181.34 user, 750.05 sys, 1466208 out
nipy_0.1.999-1~nd10.04+1_i386.build     OK      18:59.89 real, 820.13 user, 604.38 sys, 767360 out
nipy_0.1.999-1~nd10.04+1_amd64.build    OK      23:35.55 real, 1083.66 user, 597.83 sys, 929168 out
nipy_0.1.999-1~nd11.04+1_i386.build     OK      25:22.42 real, 1155.22 user, 178.50 sys, 1690696 out
nipy_0.1.999-1~nd11.04+1_amd64.build    OK      34:20.42 real, 1508.45 user, 100.01 sys, 2151632 out
nipy_0.1.999-1~nd11.10+1_i386.build     OK      21:42.96 real, 951.66 user, 136.25 sys, 1791016 out
nipy_0.1.999-1~nd11.10+1_amd64.build    OK      30:24.59 real, 1423.34 user, 156.88 sys, 2367816 out
```
