### PR TITLE
Avoid a non-informative traceback in labs.viz

### DIFF
--- a/nipy/labs/viz_tools/ortho_slicer.py
+++ b/nipy/labs/viz_tools/ortho_slicer.py
@@ -139,7 +139,14 @@ class OrthoSlicer(object):
         y_ax = ax_dict['y']
         z_ax = ax_dict['z']
         for ax in ax_dict.itervalues():
-            xmin, xmax, ymin, ymax = self._get_object_bounds(ax)
+            bounds = self._get_object_bounds(ax)
+            if not bounds:
+                # This happens if the call to _map_show was not
+                # succesful. As it happens asyncroniously (during a
+                # refresh of the figure) we capture the problem and
+                # ignore it: it only adds a non informative traceback
+                bounds = [0, 1, 0, 1]
+            xmin, xmax, ymin, ymax = bounds
             width_dict[ax] = (xmax - xmin)
         total_width = float(sum(width_dict.values()))
         for ax, width in width_dict.iteritems():


### PR DESCRIPTION
When the plotting fails for a reason or another, the axes locator rigged up to the figure could raise a traceback. This was not very informative, given that the traceback was raised asynchronously from the actual error itself. I simple avoided the problem by making the locator always work.

I couldn't figure out a way to test this, as it requires an interactive MPL backend
