### PR TITLE
DOC+TST - docstrings and tests for Image4d object

### DIFF
--- a/nipy/algorithms/registration/groupwise_registration.py
+++ b/nipy/algorithms/registration/groupwise_registration.py
@@ -87,9 +87,17 @@ class Image4d(object):
         tr_slices : inter-slice repetition time, same as tr for slices
         start   : starting acquisition time respective to the implicit
                   time origin
-        slice_order : string or array
-        slice_info : a tuple with slice axis as the first element and
-          direction as the second, for instance (2, 1)
+        slice_order : str or array-like, optional
+            If str, one of {'ascending', 'descending'}.  If array-like, then the
+            order in which the slices were collected in time.
+        interleaved : bool, optional
+            Whether slice acquisition order is interleaved.  Ignored if
+            `slice_order` is array-like.
+        slice_info : None or tuple, optional
+            None, or a tuple with slice axis as the first element and direction
+            as the second, for instance (2, 1).  If None, then guess the slice
+            axis, and direction, as the closest to the z axis, as estimated from
+            the affine.
         """
         self.affine = np.asarray(affine)
         self.tr = float(tr)

--- a/nipy/algorithms/registration/tests/test_fmri_realign4d.py
+++ b/nipy/algorithms/registration/tests/test_fmri_realign4d.py
@@ -3,7 +3,7 @@
 
 from nose.tools import assert_equal
 
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 import numpy as np
 
 from .... import load_image
@@ -28,6 +28,25 @@ def test_slice_info():
                    slice_info=(1, -1))
     assert_equal(im4d.slice_axis, 1)
     assert_equal(im4d.slice_direction, -1)
+
+
+def test_image4d_init():
+    nslices = 5
+    data = np.zeros((3, 4, nslices, 6))
+    aff = np.eye(4)
+    tr = 2.0
+    img4d = Image4d(data, aff, tr)
+    assert_array_equal(img4d.slice_order, range(nslices))
+    img4d = Image4d(data, aff, tr, slice_order='ascending')
+    assert_array_equal(img4d.slice_order, range(nslices))
+    img4d = Image4d(data, aff, tr, slice_order='descending')
+    assert_array_equal(img4d.slice_order, range(nslices)[::-1])
+    # can pass array
+    img4d = Image4d(data, aff, tr, slice_order=np.arange(nslices))
+    assert_array_equal(img4d.slice_order, range(nslices))
+    # or list
+    img4d = Image4d(data, aff, tr, slice_order=range(nslices))
+    assert_array_equal(img4d.slice_order, range(nslices))
 
 
 def test_slice_timing():


### PR DESCRIPTION
Test slice time order parameter init for Image4d object

@alexis - are these docstring edits right?

Am I right in thinking that `interleaved=True` means e.g. 0 5 1 6 2 7 3 8 4 9 10 ?

I think this isn't the usual meaning of 'interleaved' that people are used to (1 3 ... 2 4 ...). 

I guess `interleaved` gets ignored if you specify slices directly?

Would you consider extending the strings to include e.g. 'interleaved-0-2-1-3' 'interleaved-3-1-2-0' 'interleaved-0-N/2-1-n/2+1'  or something similar?  And deprecated 'interleaved'?
