### PR TITLE
Kernel smooth coordmap

### DIFF
--- a/nipy/algorithms/kernel_smooth.py
+++ b/nipy/algorithms/kernel_smooth.py
@@ -61,7 +61,7 @@ class LinearFilter(object):
         voxels.shape = (voxels.shape[0], np.product(voxels.shape[1:]))
         # physical coordinates relative to center
         X = (self.coordmap(voxels.T) - phys_center).T
-        X.shape = (self.coordmap.ndims[0],) + tuple(self.bshape)
+        X.shape = (self.coordmap.ndims[1],) + tuple(self.bshape)
         # compute kernel from these positions
         kernel = self(X, axis=0)
         kernel = _crop(kernel)


### PR DESCRIPTION
Fix bug detected by Philipp Ehses and reported on mailing list.   kernel_smooth was using the wrong coordmap dimension to reshape the output coordinates for the smoothing kernel.
