### PR TITLE
BUG fix for labs.viz_tools.test.test_cm.test_replace_inside

### DIFF
--- a/nipy/labs/viz_tools/test/test_cm.py
+++ b/nipy/labs/viz_tools/test/test_cm.py
@@ -30,6 +30,8 @@ def test_replace_inside():
     pl.switch_backend('svg')
     replace_inside(pl.cm.jet, pl.cm.hsv, .2, .8)
     # We also test with gnuplot, which is defined using function
-    replace_inside(pl.cm.gnuplot, pl.cm.gnuplot2, .2, .8)
+    if hasattr(pl.cm, 'gnuplot'):
+        # gnuplot is only in recent version of MPL
+        replace_inside(pl.cm.gnuplot, pl.cm.gnuplot2, .2, .8)
 
 


### PR DESCRIPTION
Old MPL do not have function-defined colormaps, so the corresponding
code path cannot be tested.
