### PR TITLE
BF: fix doctest to fit nibabel 1.1 behavior

### DIFF
--- a/nipy/core/image/image_spaces.py
+++ b/nipy/core/image/image_spaces.py
@@ -111,7 +111,8 @@ def xyz_affine(img, name2xyz=None):
     Nibabel images always have xyz affines
 
     >>> import nibabel as nib
-    >>> nimg = nib.Nifti1Image(arr, np.diag([2,3,4,1]))
+    >>> affine = np.diag([2, 3, 4, 1]).astype(float)
+    >>> nimg = nib.Nifti1Image(arr, affine)
     >>> xyz_affine(nimg)
     array([[ 2.,  0.,  0.,  0.],
            [ 0.,  3.,  0.,  0.],


### PR DESCRIPTION
nibabel 1.1 allowed integer affines; nibabel 1.2 enforces floating point
affines.  I adapted the xyz_affine doctest to nibabel 1.2, but forgot
about 1.1;  fix here allows both to pass
