### PR TITLE
RF: mv module clustering into utils

### DIFF
--- a/nipy/algorithms/clustering/bgmm.py
+++ b/nipy/algorithms/clustering/bgmm.py
@@ -20,7 +20,7 @@ from scipy.linalg import inv, cholesky, eigvalsh
 from scipy.special import gammaln
 import math
 
-from .clustering import kmeans
+from .utils import kmeans
 from gmm import GMM
 
 ##################################################################

--- a/nipy/algorithms/clustering/gmm.py
+++ b/nipy/algorithms/clustering/gmm.py
@@ -362,7 +362,7 @@ class GMM(object):
         x, array of shape (n_samples,self.dim)
            the data used in the estimation process
         """
-        from .clustering import kmeans
+        from .utils import kmeans
         n = x.shape[0]
 
         #1. set the priors

--- a/nipy/algorithms/clustering/setup.py
+++ b/nipy/algorithms/clustering/setup.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 def configuration(parent_package='',top_path=None):
-    
+
     from numpy.distutils.misc_util import Configuration
-    
+
     config = Configuration('clustering', parent_package, top_path)
     config.add_data_dir('tests')
     config.add_data_dir('benchmarks')

--- a/nipy/algorithms/clustering/tests/test_clustering.py
+++ b/nipy/algorithms/clustering/tests/test_clustering.py
@@ -3,7 +3,7 @@
 # to run only the simple tests:
 # python testClustering.py Test_Clustering
 
-from ..clustering import kmeans
+from ..utils import kmeans
 import nose
 import numpy as np
 import numpy.random as nr

--- a/nipy/algorithms/clustering/utils.py
+++ b/nipy/algorithms/clustering/utils.py
@@ -38,7 +38,7 @@ def kmeans(X, nbclusters=2, Labels=None, maxiter=300, delta=0.0001, verbose=0,
 
     if np.size(X.shape) > 2:
         if verbose:
-            raise ValueError("Please enter a two-diemnsional array \
+            raise ValueError("Please enter a two-dimensional array \
                               for clustering")
 
     if np.size(X.shape) == 1:
@@ -63,7 +63,7 @@ def kmeans(X, nbclusters=2, Labels=None, maxiter=300, delta=0.0001, verbose=0,
     if Labels != None:
         if np.size(Labels) == nbitems:
             Labels = Labels.astype(np.int)
-            OK = (Labels.min() > - 1) & (Labels.max() < nbclusters + 1)
+            OK = (Labels.min() > -1) & (Labels.max() < nbclusters + 1)
             if OK:
                 maxiter = int(maxiter)
                 if maxiter > 0:

--- a/nipy/labs/spatial_models/hierarchical_parcellation.py
+++ b/nipy/labs/spatial_models/hierarchical_parcellation.py
@@ -9,7 +9,7 @@ Author: Bertrand Thirion, 2008
 import numpy as np
 from numpy.random import rand
 
-from nipy.algorithms.clustering.clustering import kmeans, voronoi
+from nipy.algorithms.clustering.utils import kmeans, voronoi
 from .parcellation import MultiSubjectParcellation
 from nipy.algorithms.graph.field import Field
 from nipy.algorithms.graph.graph import wgraph_from_coo_matrix

--- a/nipy/labs/spatial_models/parcel_io.py
+++ b/nipy/labs/spatial_models/parcel_io.py
@@ -11,7 +11,7 @@ import os.path
 
 from nibabel import load, save, Nifti1Image
 
-from nipy.algorithms.clustering.clustering import kmeans
+from nipy.algorithms.clustering.utils import kmeans
 from .discrete_domain import grid_domain_from_image
 from .mroi import SubDomains
 from ..mask import intersect_masks


### PR DESCRIPTION
This is to avoid having the same name for the module and for the package
which may cause some confusion
