### PR TITLE
RF: update code causing deprecation warnings

### DIFF
--- a/nipy/io/files.py
+++ b/nipy/io/files.py
@@ -143,10 +143,7 @@ def save(img, filename, dtype=None):
     * Analyze file pair : ['.img', 'img.gz']
     """
     # Get header from image
-    try:
-        original_hdr = img.header
-    except AttributeError:
-        original_hdr = None
+    original_hdr = img.metadata.get('header')
     # Make NIFTI compatible affine_transform
     affine_3dorless_transform, pixdim = ni_affine_pixdim_from_affine(img.coordmap)
 
@@ -182,15 +179,15 @@ def save(img, filename, dtype=None):
     # Set zooms
     hdr.set_zooms(zooms)
     # save to disk
-    out_img.to_filespec(filename)
+    out_img.to_filename(filename)
     return img
 
 def _type_from_filename(filename):
     ''' Return image type determined from filename
-    
+
     Filetype is determined by the file extension in 'filename'.
     Currently the following filetypes are supported:
-    
+
     * Nifti single file : ['.nii', '.nii.gz']
     * Nifti file pair : ['.hdr', '.hdr.gz']
     * Analyze file pair : ['.img', '.img.gz']

--- a/nipy/labs/statistical_mapping.py
+++ b/nipy/labs/statistical_mapping.py
@@ -54,7 +54,7 @@ def cluster_stats(zimg, mask, height_th, height_control='fpr',
     This works only with three dimensional data
     """
     # Masking
-    if len(mask.get_shape()) > 3:
+    if len(mask.shape) > 3:
         xyz = np.where((mask.get_data() > 0).squeeze())
         zmap = zimg.get_data().squeeze()[xyz]
     else:
@@ -187,7 +187,7 @@ def get_3d_peaks(image, mask=None, threshold=0., nn=18, order_th=0):
         data = image.get_data().ravel()[bmask > 0]
         xyz = np.array(np.where(bmask > 0)).T
     else:
-        shape = image.get_shape()
+        shape = image.shape
         data = image.get_data().ravel()
         xyz = np.reshape(np.indices(shape), (3, np.prod(shape))).T
     affine = image.get_affine()

--- a/nipy/labs/utils/simul_multisubject_fmri_dataset.py
+++ b/nipy/labs/utils/simul_multisubject_fmri_dataset.py
@@ -186,7 +186,7 @@ def surrogate_3d_dataset(n_subj=1, shape=(20, 20, 20), mask=None,
         import numpy.random as nr
 
     if mask is not None:
-        shape = mask.get_shape()
+        shape = mask.shape
         mask_data = mask.get_data()
     else:
         mask_data = np.ones(shape)
@@ -276,7 +276,7 @@ def surrogate_4d_dataset(shape=(20, 20, 20), mask=None, n_scans=1, n_sess=1,
         import numpy.random as nr
 
     if mask is not None:
-        shape = mask.get_shape()
+        shape = mask.shape
         affine = mask.get_affine()
         mask_data = mask.get_data().astype('bool')
     else:


### PR DESCRIPTION
Particularly use of img.get_shape() instead of img.shape, but also use
of to_filespec, and img.header.
