### PR TITLE
RF+TST - is_image test uses get_data not __array__

### DIFF
--- a/nipy/core/image/image.py
+++ b/nipy/core/image/image.py
@@ -809,6 +809,6 @@ def is_image(obj):
     >>> is_image(c)
     False
     '''
-    if not hasattr(obj, 'coordmap'):
+    if not hasattr(obj, 'coordmap') or not hasattr(obj, 'metadata'):
         return False
     return callable(getattr(obj, 'get_data'))

--- a/nipy/core/image/tests/test_image.py
+++ b/nipy/core/image/tests/test_image.py
@@ -344,4 +344,6 @@ def test_is_image():
     c = C()
     assert_false(is_image(c))
     c.coordmap = None
+    assert_false(is_image(c))
+    c.metadata = None
     assert_true(is_image(c))


### PR DESCRIPTION
The Image API has changed, so that we depracte the use of img.**array**
in favor of img.get_data.  These changes update the `is_image` check
to use the new API.  Also added unit tests.
