### PR TITLE
RF: increase tolerance threshold for matrix_rank

### DIFF
--- a/nipy/algorithms/utils/matrices.py
+++ b/nipy/algorithms/utils/matrices.py
@@ -5,16 +5,20 @@
 import numpy as np
 import scipy.linalg as spl
 
-# This version of matrix rank is identical to the numpy.linalg version except
-# for the use of scipy.linalg.svd istead of numpy.linalg.svd.
-#
-# We added matrix_rank to numpy.linalg in # December 2009, first available in
-# numpy 1.5.0
 def matrix_rank(M, tol=None):
     ''' Return rank of matrix using SVD method
 
     Rank of the array is the number of SVD singular values of the
     array that are greater than `tol`.
+
+    This version of matrix rank is very similar to the numpy.linalg version
+    except for the use of:
+
+    * scipy.linalg.svd istead of numpy.linalg.svd.
+    * the MATLAB algorithm for default tolerance calculation
+
+    ``matrix_rank`` appeared in numpy.linalg in December 2009, first available
+    in numpy 1.5.0.
 
     Parameters
     ----------
@@ -24,7 +28,7 @@ def matrix_rank(M, tol=None):
          threshold below which SVD values are considered zero. If `tol`
          is None, and `S` is an array with singular values for `M`, and
          `eps` is the epsilon value for datatype of `S`, then `tol` set
-         to ``S.max() * eps``.
+         to ``S.max() * eps * max(M.shape)``.
 
     Examples
     --------
@@ -44,23 +48,23 @@ def matrix_rank(M, tol=None):
 
     Notes
     -----
-    Golub and van Loan [1]_ define "numerical rank deficiency" as using
-    tol=eps*S[0] (where S[0] is the maximum singular value and thus the
-    2-norm of the matrix). This is one definition of rank deficiency,
-    and the one we use here.  When floating point roundoff is the main
-    concern, then "numerical rank deficiency" is a reasonable choice. In
-    some cases you may prefer other definitions. The most useful measure
-    of the tolerance depends on the operations you intend to use on your
-    matrix. For example, if your data come from uncertain measurements
-    with uncertainties greater than floating point epsilon, choosing a
-    tolerance near that uncertainty may be preferable.  The tolerance
-    may be absolute if the uncertainties are absolute rather than
-    relative.
+    We check for numerical rank deficiency by using tol=max(M.shape) * eps *
+    S[0] (where S[0] is the maximum singular value and thus the 2-norm of the
+    matrix). This is one tolerance threshold for rank deficiency, and the
+    default algorithm used by MATLAB [2].  When floating point roundoff is the
+    main concern, then "numerical rank deficiency" is a reasonable choice. In
+    some cases you may prefer other definitions. The most useful measure of the
+    tolerance depends on the operations you intend to use on your matrix. For
+    example, if your data come from uncertain measurements with uncertainties
+    greater than floating point epsilon, choosing a tolerance near that
+    uncertainty may be preferable.  The tolerance may be absolute if the
+    uncertainties are absolute rather than relative.
 
     References
     ----------
     .. [1] G. H. Golub and C. F. Van Loan, _Matrix Computations_.
     Baltimore: Johns Hopkins University Press, 1996.
+    .. [2] http://www.mathworks.com/help/techdoc/ref/rank.html
     '''
     M = np.asarray(M)
     if M.ndim > 2:
@@ -69,7 +73,7 @@ def matrix_rank(M, tol=None):
         return int(not np.all(M==0))
     S = spl.svd(M, compute_uv=False)
     if tol is None:
-        tol = S.max() * np.finfo(S.dtype).eps
+        tol = S.max() * np.finfo(S.dtype).eps * max(M.shape)
     return np.sum(S > tol)
 
 

--- a/nipy/algorithms/utils/tests/test_matrices.py
+++ b/nipy/algorithms/utils/tests/test_matrices.py
@@ -10,8 +10,6 @@ from nose.tools import (assert_true, assert_equal, assert_false,
 
 from numpy.testing import (assert_almost_equal, assert_array_almost_equal)
 
-# Seed random number generator
-
 
 def test_matrix_rank():
     # Full rank matrix
@@ -25,6 +23,15 @@ def test_matrix_rank():
     assert_equal(matrix_rank(np.zeros((4,))), 0)
     # accepts array-like
     assert_equal(matrix_rank([1]), 1)
+    # Make rank deficient matrix
+    rng = np.random.RandomState(20120613)
+    X = rng.normal(size=(40, 10))
+    X[:, 0] = X[:, 1] + X[:, 2]
+    S = np.linalg.svd(X, compute_uv=False)
+    eps = np.finfo(X.dtype).eps
+    assert_equal(matrix_rank(X, tol=0), 10)
+    assert_equal(matrix_rank(X, tol=S.min() - eps), 10)
+    assert_equal(matrix_rank(X, tol=S.min() + eps), 9)
 
 
 def test_full_rank():


### PR DESCRIPTION
Some buildbot failures showed that we often hit the tolerance thresholds
for matrix rank deficiency. Looking a bit further suggested we got the
tolerance calculation wrong. This switches the tolerance calculation to
the MATLAB default.  Discussion at:

http://www.mail-archive.com/numpy-discussion@scipy.org/msg37819.html
