### PR TITLE
RF: making code compatible with python 2.5

### DIFF
--- a/nipy/algorithms/graph/__init__.py
+++ b/nipy/algorithms/graph/__init__.py
@@ -1,7 +1,10 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-from .graph import *
+from .graph import (Graph, WeightedGraph, wgraph_from_coo_matrix,
+                    wgraph_from_adjacency, complete_graph, mst, knn, eps_nn,
+                    lil_cc, graph_3d_grid, wgraph_from_3d_grid,
+                    concatenate_graphs)
 
 from nipy.testing import Tester
 test = Tester().test
-bench = Tester().bench 
+bench = Tester().bench

--- a/nipy/algorithms/registration/__init__.py
+++ b/nipy/algorithms/registration/__init__.py
@@ -1,11 +1,18 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-from .resample import *
-from .histogram_registration import *
-from .affine import *
-from .groupwise_registration import *
+from .resample import resample
+from .histogram_registration import (HistogramRegistration, clamp,
+                                    ideal_spacing, interp_methods)
+from .affine import (threshold, rotation_mat2vec, rotation_vec2mat, matrix44,
+                     preconditioner, inverse_affine, subgrid_affine, Affine,
+                     Affine2D, Rigid, Rigid2D, Similarity, Similarity2D,
+                     affine_transforms)
+from .groupwise_registration import (interp_slice_order, scanner_coords,
+                                     make_grid, Image4d, Realign4dAlgorithm,
+                                     resample4d, adjust_subsampling,
+                                     single_run_realign4d, realign4d, Realign4d,
+                                     FmriRealign4d)
 
 from nipy.testing import Tester
 test = Tester().test
 bench = Tester().bench
-

--- a/nipy/algorithms/registration/histogram_registration.py
+++ b/nipy/algorithms/registration/histogram_registration.py
@@ -282,7 +282,8 @@ class HistogramRegistration(object):
         # Output
         if VERBOSE:
             print ('Optimizing using %s' % fmin.__name__)
-        Tv.param = fmin(cost, tc0, *args, callback=callback, **kwargs)
+        kwargs['callback'] = callback
+        Tv.param = fmin(cost, tc0, *args, **kwargs)
         return Tv.optimizable
 
     def explore(self, T0, *args):

--- a/nipy/algorithms/segmentation/__init__.py
+++ b/nipy/algorithms/segmentation/__init__.py
@@ -1,5 +1,6 @@
-from .brain_segmentation import *
-from .vem import *
+from .brain_segmentation import (initialize_parameters, brain_segmentation)
+from .vem import (gauss_dist, laplace_dist, vm_step_gauss, weighted_median,
+                  vm_step_laplace, VEM)
 
 from nipy.testing import Tester
 test = Tester().test

--- a/nipy/core/reference/coordinate_map.py
+++ b/nipy/core/reference/coordinate_map.py
@@ -1641,9 +1641,9 @@ def _product_cmaps(*cmaps, **kwargs):
         return yy
 
     incoords = coordsys_product(*[cmap.function_domain for cmap in cmaps],
-                                name = input_name)
+                                **{'name': input_name})
     outcoords = coordsys_product(*[cmap.function_range for cmap in cmaps],
-                                 name = output_name)
+                                **{'name': output_name})
     return CoordinateMap(incoords, outcoords, function)
 
 

--- a/nipy/io/tests/test_image_io.py
+++ b/nipy/io/tests/test_image_io.py
@@ -1,5 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
+from __future__ import with_statement
 
 import numpy as np
 

--- a/nipy/io/tests/test_save.py
+++ b/nipy/io/tests/test_save.py
@@ -1,5 +1,7 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
+from __future__ import with_statement
+
 import numpy as np
 
 from nibabel.affines import from_matvec

--- a/nipy/labs/bindings/benchmarks/bench_numpy.py
+++ b/nipy/labs/bindings/benchmarks/bench_numpy.py
@@ -4,7 +4,6 @@ import time
 
 import numpy as np
 
-from ....testing import *
 from .. import copy_vector
 
 

--- a/nipy/labs/bindings/tests/test_numpy.py
+++ b/nipy/labs/bindings/tests/test_numpy.py
@@ -3,11 +3,14 @@
 # Test numpy bindings
 
 import numpy as np
-from ....testing import *
-from .. import (c_types, fff_type, npy_type, copy_vector, 
-                pass_vector, pass_vector_via_iterator)
+
+from .. import (c_types, fff_type, npy_type, copy_vector, pass_matrix,
+                pass_vector, pass_array, pass_vector_via_iterator,
+                sum_via_iterators, copy_via_iterators)
 
 
+from nose.tools import assert_equal
+from numpy.testing import assert_almost_equal, assert_array_equal
 
 MAX_TEST_SIZE = 30
 def random_shape(size):
@@ -20,7 +23,6 @@ def random_shape(size):
     else:
         return tuple(aux)
 
-    
 
 #
 # Test type conversions
@@ -80,17 +82,20 @@ def test_copy_vector_uint8():
 
 def _test_pass_vector(x):
     y = pass_vector(x)
-    assert_equal(y, x)
+    assert_array_equal(y, x)
+
 
 def test_pass_vector():
     x = np.random.rand(random_shape(1))-.5
     _test_pass_vector(x)
 
-def test_pass_vector_int32(): 
+
+def test_pass_vector_int32():
     x = (1000*(np.random.rand(random_shape(1))-.5)).astype('int32')
     _test_pass_vector(x)
 
-def test_pass_vector_uint8(): 
+
+def test_pass_vector_uint8():
     x = (256*(np.random.rand(random_shape(1)))).astype('uint8')
     _test_pass_vector(x)
 
@@ -101,15 +106,18 @@ def _test_pass_matrix(x):
     y = pass_matrix(x.T)
     yield assert_equal, y, x.T
 
+
 def test_pass_matrix():
     d0, d1 = random_shape(2)
     x = np.random.rand(d0, d1)-.5
     _test_pass_matrix(x)
 
+
 def test_pass_matrix_int32():
     d0, d1 = random_shape(2)
     x = (1000*(np.random.rand(d0, d1)-.5)).astype('int32')
     _test_pass_matrix(x)
+
 
 def test_pass_matrix_uint8():
     d0, d1 = random_shape(2)
@@ -123,22 +131,23 @@ def _test_pass_array(x):
     y = pass_array(x.T)
     yield assert_equal, y, x.T
 
+
 def test_pass_array():
     d0, d1, d2, d3 = random_shape(4)
     x = np.random.rand(d0, d1, d2, d3)-.5
     _test_pass_array(x)
+
 
 def test_pass_array_int32(): 
     d0, d1, d2, d3 = random_shape(4)
     x = (1000*(np.random.rand(d0, d1, d2, d3)-.5)).astype('int32')
     _test_pass_array(x)
 
+
 def test_pass_array_uint8():
     d0, d1, d2, d3 = random_shape(4)
     x = (256*(np.random.rand(d0, d1, d2, d3))).astype('uint8')
     _test_pass_array(x)
-
-
 
 #
 # Multi-iterator testing 
@@ -155,30 +164,36 @@ def _test_pass_vector_via_iterator(X, pos=0):
     x = pass_vector_via_iterator(X, axis=1, niters=pos)
     yield assert_equal, x, X[pos, :]
 
+
 def test_pass_vector_via_iterator():
     d0, d1 = random_shape(2)
     X = np.random.rand(d0, d1)-.5 
     _test_pass_vector_via_iterator(X)
+
 
 def test_pass_vector_via_iterator_int32():
     d0, d1 = random_shape(2)
     X = (1000*(np.random.rand(d0, d1)-.5)).astype('int32')
     _test_pass_vector_via_iterator(X)
 
+
 def test_pass_vector_via_iterator_uint8():
     d0, d1 = random_shape(2)
     X = (100*(np.random.rand(d0, d1))).astype('uint8')
     _test_pass_vector_via_iterator(X)
+
 
 def test_pass_vector_via_iterator_shift():
     d0, d1 = random_shape(2)
     X = np.random.rand(d0, d1)-.5 
     _test_pass_vector_via_iterator(X, pos=1)
 
+
 def test_pass_vector_via_iterator_shift_int32():
     d0, d1 = random_shape(2)
     X = (1000*(np.random.rand(d0, d1)-.5)).astype('int32')
     _test_pass_vector_via_iterator(X, pos=1)
+
 
 def test_pass_vector_via_iterator_shift_uint8():
     d0, d1 = random_shape(2)
@@ -193,20 +208,24 @@ def _test_copy_via_iterators(Y):
         ZT = copy_via_iterators(Y.T, axis)
         yield assert_equal, ZT, Y.T 
 
+
 def test_copy_via_iterators():
     d0, d1, d2, d3 = random_shape(4)
     Y = np.random.rand(d0, d1, d2, d3)
     _test_copy_via_iterators(Y)
+
 
 def test_copy_via_iterators_int32():
     d0, d1, d2, d3 = random_shape(4)
     Y = (1000*(np.random.rand(d0, d1, d2, d3)-.5)).astype('int32')
     _test_copy_via_iterators(Y)
 
+
 def test_copy_via_iterators_uint8():
     d0, d1, d2, d3 = random_shape(4)
     Y = (256*(np.random.rand(d0, d1, d2, d3))).astype('uint8')
     _test_copy_via_iterators(Y)
+
 
 def _test_sum_via_iterators(Y):
     for axis in range(4):
@@ -215,23 +234,25 @@ def _test_sum_via_iterators(Y):
         ZT = sum_via_iterators(Y.T, axis)
         yield assert_almost_equal, ZT, Y.T.sum(axis)
 
+
 def test_sum_via_iterators():
     d0, d1, d2, d3 = random_shape(4)
     Y = np.random.rand(d0, d1, d2, d3)
     _test_sum_via_iterators(Y)
+
 
 def test_sum_via_iterators_int32():
     d0, d1, d2, d3 = random_shape(4)
     Y = (1000*(np.random.rand(d0, d1, d2, d3)-.5)).astype('int32')
     _test_sum_via_iterators(Y)
 
+
 def test_sum_via_iterators_uint8():
     d0, d1, d2, d3 = random_shape(4)
     Y = (256*(np.random.rand(d0, d1, d2, d3))).astype('uint8')
     _test_sum_via_iterators(Y)
-    
+
 
 if __name__ == "__main__":
     import nose
     nose.run(argv=['', __file__])
-

--- a/nipy/labs/glm/__init__.py
+++ b/nipy/labs/glm/__init__.py
@@ -1,6 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-from .glm import *
+from .glm import models, contrast, ols, load
 
 from nipy.testing import Tester
 test = Tester().test

--- a/nipy/labs/glm/glm.py
+++ b/nipy/labs/glm/glm.py
@@ -3,7 +3,7 @@
 import numpy as np
 import scipy.stats as sps
 
-import kalman
+from . import kalman
 from ..utils import mahalanobis
 from ..utils.zscore import zscore
 

--- a/nipy/labs/spatial_models/tests/test_mroi.py
+++ b/nipy/labs/spatial_models/tests/test_mroi.py
@@ -8,9 +8,10 @@ in ~/.nipy/tests/data
 """
 
 import numpy as np
-from numpy.testing import assert_equal
-from ..mroi import *
+from ..mroi import subdomain_from_array, subdomain_from_balls
 from ..discrete_domain import domain_from_binary_array
+
+from numpy.testing import assert_equal
 
 shape = (5, 6, 7)
 
@@ -92,7 +93,6 @@ def test_roi_features():
     """
     """
     mroi = make_subdomain()
-    aux = np.random.randn(np.prod(shape))
     dshape = (8, 3)
     data = np.random.randn(*dshape)
     mroi.set_roi_feature('data_mean', data)

--- a/nipy/labs/spatial_models/tests/test_parcel_io.py
+++ b/nipy/labs/spatial_models/tests/test_parcel_io.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 from os.path import exists
 import numpy as np
 from nibabel import Nifti1Image, save

--- a/nipy/labs/utils/__init__.py
+++ b/nipy/labs/utils/__init__.py
@@ -1,6 +1,7 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-from .routines import *
+from .routines import (quantile, median, mahalanobis, svd, permutations,
+                       combinations, gamln, psi)
 from .zscore import zscore
 
 from nipy.testing import Tester

--- a/nipy/labs/utils/mask.py
+++ b/nipy/labs/utils/mask.py
@@ -9,4 +9,4 @@ warnings.warn(DeprecationWarning(
     "'nipy.labs.mask'."))
 
 # Absolute import, as 'import *' doesnot work with relative imports
-from ..mask import *
+from nipy.labs.mask import *

--- a/nipy/modalities/fmri/fmristat/tests/test_model.py
+++ b/nipy/modalities/fmri/fmristat/tests/test_model.py
@@ -1,5 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
+from __future__ import with_statement
 
 import numpy as np
 


### PR DESCRIPTION
Adding **future** import for with_statement
Making relative imports specific (avoiding from .something import _)
Some general cleanup of nipy/labs/bindings/tests/test_numpy.py
Two instances of kwargs after *args changed to use *_kwargs.
