### PR TITLE
BF: remove use of nibabel and nipy image get_shape

### DIFF
--- a/examples/labs/need_data/demo_roi.py
+++ b/examples/labs/need_data/demo_roi.py
@@ -57,7 +57,7 @@ smin = 5  # size threshold on bblobs
 # prepare the data
 nim = load(input_image)
 affine = nim.get_affine()
-shape = nim.get_shape()
+shape = nim.shape
 data = nim.get_data()
 values = data[data != 0]
 

--- a/nipy/interfaces/spm.py
+++ b/nipy/interfaces/spm.py
@@ -53,7 +53,7 @@ spm_jobman('run', jobs);
 
 def scans_for_fname(fname):
     img = load(fname)
-    n_scans = img.get_shape()[3]
+    n_scans = img.shape[3]
     scans = np.zeros((n_scans, 1), dtype=object)
     for sno in range(n_scans):
         scans[sno] = '%s,%d' % (fname, sno+1)

--- a/nipy/labs/spatial_models/bsa_io.py
+++ b/nipy/labs/spatial_models/bsa_io.py
@@ -83,7 +83,7 @@ def make_bsa_image(
 
     # Read the referential information
     nim = load(mask_images[0])
-    ref_dim = nim.get_shape()[:3]
+    ref_dim = nim.shape[:3]
     affine = nim.get_affine()
 
     # Read the masks and compute the "intersection"

--- a/nipy/labs/statistical_mapping.py
+++ b/nipy/labs/statistical_mapping.py
@@ -260,7 +260,7 @@ def onesample_test(data_images, vardata_images, mask_images, stat_id,
                                        stat_id=stat_id)
 
     # Compute z-map image
-    zmap = np.zeros(data_images[0].get_shape()).squeeze()
+    zmap = np.zeros(data_images[0].shape).squeeze()
     zmap[list(xyz)] = ptest.zscore()
     zimg = Image(zmap, data_images[0].get_affine())
 
@@ -309,7 +309,7 @@ def twosample_test(data_images, vardata_images, mask_images, labels, stat_id,
             stat_id=stat_id)
 
     # Compute z-map image
-    zmap = np.zeros(data_images[0].get_shape()).squeeze()
+    zmap = np.zeros(data_images[0].shape).squeeze()
     zmap[list(xyz)] = ptest.zscore()
     zimg = Image(zmap, data_images[0].get_affine())
 
@@ -356,7 +356,7 @@ def linear_model_fit(data_images, mask_images, design_matrix, vector):
     c = G.contrast(vector)
 
     # Compute z-map image
-    zmap = np.zeros(data_images[0].get_shape()).squeeze()
+    zmap = np.zeros(data_images[0].shape).squeeze()
     zmap[list(xyz)] = c.zscore()
     zimg = Image(zmap, data_images[0].get_affine())
 
@@ -384,12 +384,12 @@ class LinearModel(object):
         nomask = mask == None
         if nomask:
             self.xyz = None
-            self.axis = len(data[0].get_shape()) - 1
+            self.axis = len(data[0].shape) - 1
         else:
             self.xyz = np.where(mask.get_data() > 0)
             self.axis = 1
 
-        self.spatial_shape = data[0].get_shape()[0: - 1]
+        self.spatial_shape = data[0].shape[0: -1]
         self.affine = data[0].get_affine()
 
         self.glm = []


### PR DESCRIPTION
`get_shape` method deprecated in both nibabel and nipy.
