### PR TITLE
RF: use fix0 to fix rollimg axis errors for TR=0

### DIFF
--- a/nipy/core/image/image.py
+++ b/nipy/core/image/image.py
@@ -678,7 +678,7 @@ def rollaxis(img, axis, inverse=False):
     return img.reordered_axes(order).reordered_reference(order)
 
 
-def rollimg(img, axis, start=0, fix0=False):
+def rollimg(img, axis, start=0, fix0=True):
     """ Roll `axis` backwards in the inputs, until it lies before `start`
 
     Parameters

--- a/nipy/core/image/tests/test_image.py
+++ b/nipy/core/image/tests/test_image.py
@@ -391,12 +391,15 @@ def test_rollimg():
     im_rolled = rollimg(im_unamb, 'l')
     assert_array_equal(im_rolled.get_data(),
                        im_unamb.get_data().transpose([3,0,1,2]))
-    # Zero row / col means we can't find an axis mapping, by default
+    # Zero row / col means we can't find an axis mapping, when fix0 is false
     aff_z = np.diag([1, 2, 3, 0, 1])
     im_z = Image(data, AT('ijkl', 'xyzt', aff_z))
-    assert_raises(AxisError, rollimg, im_z, 't')
-    # Unless we turn on our zero detector
+    assert_raises(AxisError, rollimg, im_z, 't', fix0=False)
+    # But we can work it out if we turn on our zero detector
     assert_equal(rollimg(im_z, 't', fix0=True).coordmap,
+                 AT('lijk', 'xyzt', aff_z[:, (3, 0, 1, 2, 4)]))
+    # That's the default
+    assert_equal(rollimg(im_z, 't').coordmap,
                  AT('lijk', 'xyzt', aff_z[:, (3, 0, 1, 2, 4)]))
     # Non square is OK
     aff_r = np.array([[1, 0, 0, 10],


### PR DESCRIPTION
Many FMRI images have TR=0 in the affine, and this causes an error with
the previous default fix0=False for rolimg.  The case is common, and I
think the fix is safe, so setting to default.
