### PR TITLE
explicitly declare slice order in fmri realignment example 

### DIFF
--- a/examples/space_time_realign.py
+++ b/examples/space_time_realign.py
@@ -40,7 +40,7 @@ runs = [load(run) for run in runnames]
 
 # Declare interleaved ascending slice order
 nslices = runs[0].shape[2]
-slice_order = range(nslices)[0::2] + range(nslices)[1::2]
+slice_order = range(0, nslices, 2) + range(1, nslices, 2)
 print('Slice order: %s' % slice_order)
 
 # Spatio-temporal realigner


### PR DESCRIPTION
To complement Matthew's PR on refactoring labs examples - as suggested by Satra.
