### PR TITLE
use_derivatives fix

### DIFF
--- a/nipy/algorithms/registration/optimizer.py
+++ b/nipy/algorithms/registration/optimizer.py
@@ -48,7 +48,7 @@ def configure_optimizer(optimizer, fprime=None, fhess=None, **kwargs):
 
 
 def use_derivatives(optimizer):
-    if optimizer in ('fmin_simplex', 'fmin_powell'):
+    if optimizer in ('simplex', 'powell'):
         return False
     else:
         return True


### PR DESCRIPTION
minor fix of use_derivatives, seems that the name given as parameters are not 'fmin_' prefixed (due to configure_optimizer specification), which could bring speed issue with powell or simplex optimizers.
