### PR TITLE
Refactor axis finding

### DIFF
--- a/examples/fiac/fiac_example.py
+++ b/examples/fiac/fiac_example.py
@@ -182,7 +182,7 @@ def run_model(subj, run):
     # Load in the fMRI data, saving it as an array.  It is transposed to have
     # time as the first dimension, i.e. fmri[t] gives the t-th volume.
     fmri_im = futil.get_fmri(path_info) # an Image
-    fmri_im = rollimg(fmri_im, 't', fix0=True)
+    fmri_im = rollimg(fmri_im, 't')
     fmri = fmri_im.get_data() # now, it's an ndarray
 
     nvol, volshape = fmri.shape[0], fmri.shape[1:]

--- a/nipy/core/reference/coordinate_map.py
+++ b/nipy/core/reference/coordinate_map.py
@@ -1848,7 +1848,7 @@ def append_io_dim(cm, in_name, out_name, start=0, step=1):
     return product(cm, extra_cmap)
 
 
-def axmap(coordmap, direction='in2out', fix0=False):
+def axmap(coordmap, direction='in2out', fix0=True):
     """ Return mapping between input and output axes
 
     Parameters
@@ -1901,7 +1901,7 @@ def axmap(coordmap, direction='in2out', fix0=False):
     return in2out_map, out2in_map
 
 
-def input_axis_index(coordmap, axis_id, fix0=False):
+def input_axis_index(coordmap, axis_id, fix0=True):
     """ Return input axis index for `axis_id`
 
     `axis_id` can be integer, or a name of an input axis, or it can be the name
@@ -1916,7 +1916,8 @@ def input_axis_index(coordmap, axis_id, fix0=False):
         input axis, or the name of an output axis that should have a
         corresponding input axis (see Raises section).
     fix0: bool, optional
-        Whether to fix potential 0 TR in affine
+        Whether to fix potential single 0 on diagonal of affine.  This often
+        happens when loading nifti images with TR set to 0.
 
     Returns
     -------
@@ -1961,7 +1962,7 @@ def input_axis_index(coordmap, axis_id, fix0=False):
     return in_no
 
 
-def io_axis_indices(coordmap, axis_id, fix0=False):
+def io_axis_indices(coordmap, axis_id, fix0=True):
     """ Return input and output axis index for id `axis_id` in `coordmap`
 
     Parameters

--- a/nipy/core/reference/tests/test_coordinate_map.py
+++ b/nipy/core/reference/tests/test_coordinate_map.py
@@ -718,13 +718,21 @@ def test_axmap():
                                'i': 2, 'j': 0, 'k': 1})
     assert_equal(axmap(cmap, 'out2in'), {2: 0, 0: 1, 1: 2,
                                          'z': 0, 'x': 1, 'y': 2})
+    # Test in presence of nasty zero
     cmap = AffineTransform('ijk', 'xyz', np.diag([2, 3, 0, 1]))
-    assert_equal(axmap(cmap), {0: 0, 1: 1, 2: None,
-                               'i': 0, 'j': 1, 'k': None})
-    assert_equal(axmap(cmap, 'out2in'), {0: 0, 1: 1, 2: None,
-                                         'x': 0, 'y': 1, 'z': None})
+    # Default is to fix zero
+    assert_equal(axmap(cmap), {0: 0, 1: 1, 2: 2,
+                               'i': 0, 'j': 1, 'k': 2})
     assert_equal(axmap(cmap, fix0=True), {0: 0, 1: 1, 2: 2,
                                           'i': 0, 'j': 1, 'k': 2})
+    assert_equal(axmap(cmap, 'out2in'), {0: 0, 1: 1, 2: 2,
+                                         'x': 0, 'y': 1, 'z': 2})
+    # If turned off, we can't find the axis anymore
+    assert_equal(axmap(cmap, fix0=False), {0: 0, 1: 1, 2: None,
+                                           'i': 0, 'j': 1, 'k': None})
+    assert_equal(axmap(cmap, 'out2in', fix0=False), {0: 0, 1: 1, 2: None,
+                                                    'x': 0, 'y': 1, 'z': None})
+    # Need in2out or out2in as action strings
     assert_raises(ValueError, axmap, cmap, 'do what exactly?')
     # Non-square
     cmap = AffineTransform('ij', 'xyz', [[0, 1, 0],
@@ -792,12 +800,13 @@ def test_input_axis_index():
     assert_raises(AxisError, input_axis_index, cmap_b, 'i')
     # Name not found, AxisError
     assert_raises(AxisError, input_axis_index, cmap_b, 'q')
-    # 0 usually leads to no match
+    # 0 leads to no match if fix0 turned off
     cmap_z = AffineTransform('ijk', 'xyz', np.diag([2, 3, 0, 1]))
-    assert_equal(input_axis_index(cmap_z, 'y'), 1)
-    assert_raises(AxisError, input_axis_index, cmap_z, 'z')
-    # Unless fix0 in place
+    assert_equal(input_axis_index(cmap_z, 'z'), 2)
     assert_equal(input_axis_index(cmap_z, 'z', fix0=True), 2)
+    assert_raises(AxisError, input_axis_index, cmap_z, 'z', fix0=False)
+    # Other axes not affected in presence of 0
+    assert_equal(input_axis_index(cmap_z, 'y'), 1)
 
 
 def test_io_axis_indices():
@@ -830,14 +839,19 @@ def test_io_axis_indices():
     assert_equal(io_axis_indices(cmap_b, 0), (0, 0))
     # Name not found, AxisError
     assert_raises(AxisError, io_axis_indices, cmap_b, 'q')
-    # 0 usually leads to no match
+    # 0 leads to no match if fix0 set to false
     cmap_z = AffineTransform('ijk', 'xyz', np.diag([2, 3, 0, 1]))
     assert_equal(io_axis_indices(cmap_z, 'y'), (1, 1))
-    assert_equal(io_axis_indices(cmap_z, 'z'), (None, 2))
+    assert_equal(io_axis_indices(cmap_z, 'z'), (2, 2))
+    assert_equal(io_axis_indices(cmap_z, 'z', fix0=False), (None, 2))
     # For either input or output
-    assert_equal(io_axis_indices(cmap_z, 'k'), (2, None))
-    # Unless fix0 in place
-    assert_equal(io_axis_indices(cmap_z, 'z', fix0=True), (2, 2))
+    assert_equal(io_axis_indices(cmap_z, 'k'), (2, 2))
+    assert_equal(io_axis_indices(cmap_z, 'k', fix0=False), (2, None))
+    # axis name and number access without fix0
+    cmap = AffineTransform('ijkt', 'xyzt', np.diag([1, 1, 1, 0, 1]))
+    assert_raises(AxisError, io_axis_indices, cmap, 't', fix0=False)
+    in_ax, out_ax = io_axis_indices(cmap, -1, fix0=False)
+    assert_equal((in_ax, out_ax), (3, None))
     # Non-square is OK
     cmap = AffineTransform('ij', 'xyz', [[0, 1, 0],
                                          [0, 0, 0],

--- a/nipy/io/nifti_ref.py
+++ b/nipy/io/nifti_ref.py
@@ -176,7 +176,7 @@ class NiftiError(Exception):
     pass
 
 
-def nipy2nifti(img, data_dtype=None, strict=None, fix0=False):
+def nipy2nifti(img, data_dtype=None, strict=None, fix0=True):
     """ Return NIFTI image from nipy image `img`
 
     Parameters

--- a/nipy/io/tests/test_nifti_ref.py
+++ b/nipy/io/tests/test_nifti_ref.py
@@ -339,29 +339,39 @@ def test_save_toffset():
                   CS(xyz_names + ('u', t_name, 'v')),
                   np.diag([3, 4, 5, 6, 0, 7, 1]))
         assert_equal(nipy2nifti(Image(data, cmap)).shape, shape_shifted)
-        # toffset, non-matching error
+        # toffset with 0 on TR (time) diagonal
         aff_z1 = from_matvec(np.diag([2., 3, 4, 5, 0, 7]),
                              [11, 12, 13, 14, 15, 16])
         cmap = AT(CS(('i', 'j', 'k', 'u', t_name, 'v')),
                   CS(xyz_names + ('u', t_name, 'v')),
                   aff_z1)
-        assert_raises(NiftiError, nipy2nifti, Image(data, cmap))
-        # Unless fix0 set
+        # Default is to fix the zero
+        assert_equal(nipy2nifti(Image(data, cmap)).shape,
+                     shape_shifted)
         assert_equal(nipy2nifti(Image(data, cmap), fix0=True).shape,
                      shape_shifted)
-        # Even this doesn't work if there is more than one zero row and column
+        # Unless fix0 is False
+        assert_raises(NiftiError, nipy2nifti, Image(data, cmap), fix0=False)
+        # Fix doesn't work if there is more than one zero row and column
         aff_z2 = from_matvec(np.diag([2., 3, 4, 0, 0, 7]),
                              [11, 12, 13, 14, 15, 16])
         cmap = AT(CS(('i', 'j', 'k', 'u', t_name, 'v')),
                   CS(xyz_names + ('u', t_name, 'v')),
                   aff_z2)
         assert_raises(NiftiError, nipy2nifti, Image(data, cmap), fix0=True)
-    # No problem for non-time
+    # zeros on the diagonal are not a problem for non-time, with toffset,
+    # because we don't need to set the 'time' part of the translation vector,
+    # and therefore we don't need to know which *output axis* is time-like
     for t_name in 'hz', 'ppm', 'rads':
         cmap = AT(CS(('i', 'j', 'k', 'u', t_name, 'v')),
                   CS(xyz_names + ('u', t_name, 'v')),
-                  aff)
-        assert_equal(nipy2nifti(Image(data, cmap), fix0=True).shape,
+                  aff_z1)
+        assert_equal(nipy2nifti(Image(data, cmap), fix0=False).shape,
+                     shape_shifted)
+        cmap = AT(CS(('i', 'j', 'k', 'u', t_name, 'v')),
+                  CS(xyz_names + ('u', t_name, 'v')),
+                  aff_z2)
+        assert_equal(nipy2nifti(Image(data, cmap), fix0=False).shape,
                      shape_shifted)
 
 


### PR DESCRIPTION
After using it for a bit, it seemed to me that we should always fix the very common TR = 0 axis problem (at least by default).   Changed the code and tests to reflect this. 
