### PR TITLE
MRG: thinking of an interface for HRF convolution

### DIFF
--- a/nipy/modalities/fmri/tests/test_utils.py
+++ b/nipy/modalities/fmri/tests/test_utils.py
@@ -23,11 +23,13 @@ from ..utils import (
     interp,
     linear_interp,
     step_function,
+    TimeConvolver,
     convolve_functions,
     )
 from .. import hrf
 
-from nose.tools import (assert_equal, assert_false, raises, assert_raises)
+from nose.tools import (assert_equal, assert_true, assert_false, raises,
+                        assert_raises)
 
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_almost_equal)
@@ -153,9 +155,6 @@ def test_blocks():
     assert_equal(str(b), 'funky_chicken(t)')
 
 
-
-
-
 def numerical_convolve(func1, func2, interval, dt):
     mni, mxi = interval
     time = np.arange(mni, mxi, dt)
@@ -176,57 +175,76 @@ def test_convolve_functions():
     ff1 = lambdify(t, f1)
     # Time delta
     dt = 1e-3
-    # The convolution of ``f1`` with itself is a triangular wave on
-    # [0, 2], peaking at 1 with height 1
-    tri = convolve_functions(f1, f1, [0, 2], [0, 2], dt, name='conv')
-    assert_equal(str(tri), 'conv(t)')
-    ftri = lambdify(t, tri)
+    # Numerical convolution to test against
+    # The convolution of ``f1`` with itself is a triangular wave on [0, 2],
+    # peaking at 1 with height 1
     time, value = numerical_convolve(ff1, ff1, [0, 2], dt)
-    y = ftri(time)
-    # numerical convolve about the same as ours
-    assert_array_almost_equal(value, y)
-    # peak is at 1
-    assert_array_almost_equal(time[np.argmax(y)], 1)
-    # Flip the interval and get the same result
-    for seq1, seq2 in (((0, 2), (2, 0)),
-                       ((2, 0), (0, 2)),
-                       ((2, 0), (2, 0))):
-        tri = convolve_functions(f1, f1, seq1, seq2, dt)
+    # shells to wrap convolve kernel version
+    def kern_conv1(f1, f2, f1_interval, f2_interval, dt, fill=0, name=None):
+        kern = TimeConvolver(f1, f1_interval, dt, fill)
+        return kern.convolve(f2, f2_interval, name=name)
+    def kern_conv2(f1, f2, f1_interval, f2_interval, dt, fill=0, name=None):
+        kern = TimeConvolver(f2, f2_interval, dt, fill)
+        return kern.convolve(f1, f1_interval, name=name)
+    for cfunc in (convolve_functions, kern_conv1, kern_conv2):
+        tri = cfunc(f1, f1, [0, 2], [0, 2], dt, name='conv')
+        assert_equal(str(tri), 'conv(t)')
         ftri = lambdify(t, tri)
         y = ftri(time)
+        # numerical convolve about the same as ours
         assert_array_almost_equal(value, y)
-    # offset square wave by 1 - offset triangle by 1
-    f2 = (t > 1) * (t < 2)
-    tri = convolve_functions(f1, f2, [0, 3], [0, 3], dt)
-    ftri = lambdify(t, tri)
-    o1_time = np.arange(0, 3, dt)
-    z1s = np.zeros((np.round(1./dt)))
-    assert_array_almost_equal(ftri(o1_time), np.r_[z1s, value])
-    # Same for input function
-    tri = convolve_functions(f2, f1, [0, 3], [0, 3], dt)
-    ftri = lambdify(t, tri)
-    assert_array_almost_equal(ftri(o1_time), np.r_[z1s, value])
-    # 2 seconds for both
-    tri = convolve_functions(f2, f2, [0, 4], [0, 4], dt)
-    ftri = lambdify(t, tri)
-    o2_time = np.arange(0, 4, dt)
-    assert_array_almost_equal(ftri(o2_time), np.r_[z1s, z1s, value])
-    # offset by -0.5 - offset triangle by -0.5
-    f3 = (t > -0.5) * (t < 0.5)
-    tri = convolve_functions(f1, f3, [0, 2], [-0.5, 1.5], dt)
-    ftri = lambdify(t, tri)
-    o1_time = np.arange(-0.5, 1.5, dt)
-    assert_array_almost_equal(ftri(o1_time), value)
-    # Same for input function
-    tri = convolve_functions(f3, f1, [-0.5, 1.5], [0, 2], dt)
-    ftri = lambdify(t, tri)
-    assert_array_almost_equal(ftri(o1_time), value)
-    # -1 second for both
-    tri = convolve_functions(f3, f3, [-0.5, 1.5], [-0.5, 1.5], dt)
-    ftri = lambdify(t, tri)
-    o2_time = np.arange(-1, 1, dt)
-    assert_array_almost_equal(ftri(o2_time), value)
-    # Check it's OK to be off the dt grid
-    tri = convolve_functions(f1, f1, [dt/2, 2 + dt/2], [0, 2], dt, name='conv')
-    ftri = lambdify(t, tri)
-    assert_array_almost_equal(ftri(time), value, 3)
+        # peak is at 1
+        assert_array_almost_equal(time[np.argmax(y)], 1)
+        # Flip the interval and get the same result
+        for seq1, seq2 in (((0, 2), (2, 0)),
+                        ((2, 0), (0, 2)),
+                        ((2, 0), (2, 0))):
+            tri = cfunc(f1, f1, seq1, seq2, dt)
+            ftri = lambdify(t, tri)
+            y = ftri(time)
+            assert_array_almost_equal(value, y)
+        # offset square wave by 1 - offset triangle by 1
+        f2 = (t > 1) * (t < 2)
+        tri = cfunc(f1, f2, [0, 3], [0, 3], dt)
+        ftri = lambdify(t, tri)
+        o1_time = np.arange(0, 3, dt)
+        z1s = np.zeros((np.round(1./dt)))
+        assert_array_almost_equal(ftri(o1_time), np.r_[z1s, value])
+        # Same for input function
+        tri = cfunc(f2, f1, [0, 3], [0, 3], dt)
+        ftri = lambdify(t, tri)
+        assert_array_almost_equal(ftri(o1_time), np.r_[z1s, value])
+        # 2 seconds for both
+        tri = cfunc(f2, f2, [0, 4], [0, 4], dt)
+        ftri = lambdify(t, tri)
+        o2_time = np.arange(0, 4, dt)
+        assert_array_almost_equal(ftri(o2_time), np.r_[z1s, z1s, value])
+        # offset by -0.5 - offset triangle by -0.5
+        f3 = (t > -0.5) * (t < 0.5)
+        tri = cfunc(f1, f3, [0, 2], [-0.5, 1.5], dt)
+        ftri = lambdify(t, tri)
+        o1_time = np.arange(-0.5, 1.5, dt)
+        assert_array_almost_equal(ftri(o1_time), value)
+        # Same for input function
+        tri = cfunc(f3, f1, [-0.5, 1.5], [0, 2], dt)
+        ftri = lambdify(t, tri)
+        assert_array_almost_equal(ftri(o1_time), value)
+        # -1 second for both
+        tri = cfunc(f3, f3, [-0.5, 1.5], [-0.5, 1.5], dt)
+        ftri = lambdify(t, tri)
+        o2_time = np.arange(-1, 1, dt)
+        assert_array_almost_equal(ftri(o2_time), value)
+        # Check it's OK to be off the dt grid
+        tri = cfunc(f1, f1, [dt/2, 2 + dt/2], [0, 2], dt, name='conv')
+        ftri = lambdify(t, tri)
+        assert_array_almost_equal(ftri(time), value, 3)
+        # Check fill value
+        nan_tri = cfunc(f1, f1, [0, 2], [0, 2], dt, fill=np.nan)
+        nan_ftri = lambdify(t, nan_tri)
+        y = nan_ftri(time)
+        assert_array_equal(y, value)
+        assert_true(np.all(np.isnan(nan_ftri(np.arange(-2, 0)))))
+        assert_true(np.all(np.isnan(nan_ftri(np.arange(4, 6)))))
+        # The original fill value was 0
+        assert_array_equal(ftri(np.arange(-2, 0)), 0)
+        assert_array_equal(ftri(np.arange(4, 6)), 0)

--- a/nipy/modalities/fmri/utils.py
+++ b/nipy/modalities/fmri/utils.py
@@ -23,7 +23,6 @@ from __future__ import absolute_import
 import itertools
 
 import numpy as np
-import numpy.fft as FFT
 from scipy.interpolate import interp1d
 
 import sympy
@@ -388,6 +387,84 @@ def blocks(intervals, amplitudes=None, name=None):
     return step_function(t, v, name=name)
 
 
+def _eval_for(f, interval, dt):
+    """ Return x and y for function `f` over `interval` and delta `dt`
+    """
+    real_f = lambdify_t(f)
+    f_mn, f_mx = sorted(interval)
+    time = np.arange(f_mn, f_mx, float(dt)) # time values with support for g
+    vals = real_f(time).astype(float)
+    return vals
+
+
+def _conv_fx_gx(f_vals, g_vals, dt, min_f, min_g):
+    """ Numerical convolution given f(x), min(x) for two functions
+    """
+    vals = np.convolve(f_vals, g_vals) * dt # Full by default
+    # f and g have been implicitly translated by -f_mn and -g_mn respectively,
+    # because in terms of array indices, they both now start at 0.
+    # Translate by f and g offsets
+    time = np.arange(len(vals)) * dt + min_f + min_g
+    return time, vals
+
+
+class TimeConvolver(object):
+    """ Make a convolution kernel from a symbolic function of t
+
+    A convolution kernel is a function with extra attributes to allow it to
+    function as a kernel for numerical convolution (see
+    :func:`convolve_functions`).
+
+    Parameters
+    ----------
+    expr : sympy expression
+        An expression that is a function of t only.
+    support : 2 sequence
+        Sequence is ``(low, high)`` where expression is defined between ``low``
+        and ``high``, and can be assumed to be `fill` otherwise
+    delta : float
+        smallest change in domain of `expr` to use for numerical evaluation of
+        `expr`
+    """
+    def __init__(self, expr, support, delta, fill=0):
+        self.expr = expr
+        self.support = support
+        self.delta = delta
+        self.fill = fill
+        self._vals = _eval_for(expr, self.support, self.delta)
+
+    def convolve(self, g, g_interval, name=None, **kwargs):
+        """ Convolve sympy expression `g` with this kernel
+
+        Parameters
+        ----------
+        g : sympy expr
+            An expression that is a function of t only.
+        g_interval : (2,) sequence of floats
+            Start and end of the interval of t over which to convolve g
+        name : None or str, optional
+            Name of the convolved function in the resulting expression.
+            Defaults to one created by ``utils.interp``.
+        \*\*kwargs : keyword args, optional
+            Any other arguments to pass to the ``interp1d`` function in creating
+            the numerical function for `fg`.
+
+        Returns
+        -------
+        fg : sympy expr
+            An symbolic expression that is a function of t only, and that can be
+            lambdified to produce a function returning the convolved series from
+            an input array.
+        """
+        g_vals = _eval_for(g, g_interval, self.delta)
+        fg_time, fg_vals = _conv_fx_gx(self._vals,
+                                       g_vals,
+                                       self.delta,
+                                       min(self.support),
+                                       min(g_interval))
+        return interp(fg_time, fg_vals, fill=self.fill, name=name, **kwargs)
+
+
 def convolve_functions(f, g, f_interval, g_interval, dt,
                        fill=0, name=None, **kwargs):
     """ Expression containing numerical convolution of `fn1` with `fn2`
@@ -401,7 +478,7 @@ def convolve_functions(f, g, f_interval, g_interval, dt,
     f_interval : (2,) sequence of float
        The start and end of the interval of t over which to convolve values of f
     g_interval : (2,) sequence of floats
-       Start and end of the interval of t over to convolve g
+       Start and end of the interval of t over which to convolve g
     dt : float
        Time step for discretization.  We use this for creating the
        interpolator to form the numerical implementation
@@ -412,7 +489,7 @@ def convolve_functions(f, g, f_interval, g_interval, dt,
        Defaults to one created by ``utils.interp``.
     \*\*kwargs : keyword args, optional
        Any other arguments to pass to the ``interp1d`` function in creating the
-       numerical funtion for `fg`.
+       numerical function for `fg`.
 
     Returns
     -------
@@ -459,18 +536,11 @@ def convolve_functions(f, g, f_interval, g_interval, dt,
     """
     # - so the peak value is 1-dt - rather than 1 - but we get the same
     # result from using np.convolve - see tests.
-    real_f = lambdify_t(f)
-    real_g = lambdify_t(g)
-    dt = float(dt)
-    f_mn, f_mx = sorted(f_interval)
-    f_time = np.arange(f_mn, f_mx, dt) # time values with support for f
-    f_vals = real_f(f_time).astype(float)
-    g_mn, g_mx = sorted(g_interval)
-    g_time = np.arange(g_mn, g_mx, dt) # time values with support for g
-    g_vals = real_g(g_time).astype(float)
-    # f and g have been implicitly translated by -f_mn and -g_mn respectively,
-    # because in terms of array indices, they both now start at 0
-    value = np.convolve(f_vals, g_vals) * dt # Full by default
-    # Translate by f and g offsets
-    fg_time = np.arange(len(value)) * dt + f_mn + g_mn
-    return interp(fg_time, value, fill=fill, name=name, **kwargs)
+    f_vals = _eval_for(f, f_interval, dt)
+    g_vals = _eval_for(g, g_interval, dt)
+    fg_time, fg_vals = _conv_fx_gx(f_vals,
+                                   g_vals,
+                                   dt,
+                                   min(f_interval),
+                                   min(g_interval))
+    return interp(fg_time, fg_vals, fill=fill, name=name, **kwargs)


### PR DESCRIPTION
I'm trying to work out a good interface to express the fact that generally,
when we convolve things with HRFs, we want the same interval for the kernel,
and the same dt.

Maybe we could have an HRF object, that has a 'convolve' method, maybe an
'evaluate' method (to evaluation the real function at given time values, and a
`symfunc` property for the symbolic function.

I haven't really thought this last part through.