### PR TITLE
BF+TST: bug in nifti convert for 'unknown' space

### DIFF
--- a/nipy/io/nifti_ref.py
+++ b/nipy/io/nifti_ref.py
@@ -336,12 +336,15 @@ def nipy2nifti(img, data_dtype=None, strict=None, fix0=True):
         elif not out_space in ncrs.unknown_space: # no space we recognize
             raise NiftiError('Image world not a NIFTI world')
         else: # unknown space requires affine that matches
+            # Set guessed shape to set zooms correctly
+            hdr.set_data_shape(img.shape)
+            # Use qform set to set the zooms, but with 'unknown' code
+            hdr.set_qform(xyz_affine, 'unknown')
+            hdr.set_sform(None)
             if not np.allclose(xyz_affine, hdr.get_base_affine()):
                 raise NiftiError("Image world is 'unknown' but affine not "
                                  "compatible; please reset image world or "
                                  "affine")
-            hdr.set_qform(None)
-            hdr.set_sform(None)
     # Use list() to get .index method for python < 2.6
     input_names = list(coordmap.function_domain.coord_names)
     spatial_names = input_names[:3]

--- a/nipy/io/tests/test_nifti_ref.py
+++ b/nipy/io/tests/test_nifti_ref.py
@@ -119,6 +119,14 @@ def test_unknown():
     assert_true(np.allclose(bare_affine, displaced_img.coordmap.affine))
     nimg = nipy2nifti(displaced_img)
     assert_array_equal(nimg.get_affine(), bare_affine)
+    # Get and check coordinate map
+    inimg = nifti2nipy(nimg)
+    assert_true(inimg.coordmap.function_range in unknown_space)
+    # This also so if there is no header
+    displaced_img.metadata.pop('header')
+    nimg = nipy2nifti(displaced_img)
+    assert_array_equal(nimg.get_affine(), bare_affine)
+    # Get and check coordinate map
     inimg = nifti2nipy(nimg)
     assert_true(inimg.coordmap.function_range in unknown_space)
 


### PR DESCRIPTION
'unknown' space should work if the header matches, but if there is no header,
the zooms weren't being set, and the check was failing.  Fix and test.
