### PR TITLE
RF: make .travis.yml use travis Python and wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,39 @@
 # vim ft=yaml
-# travis-ci.org definition for nipy build
-#
-# We pretend to be erlang because we need can't use the python support in
-# travis-ci; it uses virtualenvs, they do not have numpy, scipy, matplotlib,
-# and it is impractical to build them
-language: erlang
-env:
-    # Enable python 2 and python 3 builds. Python3.2 available in Ubuntu 12.04.
-    - PYTHON=python EASY_INSTALL=easy_install PIP=pip COVERAGE=--with-coverage
-    - PYTHON=python3 EASY_INSTALL=easy_install3 PIP=pip3.2
-install:
-    - sudo apt-get update
-    - sudo apt-get install $PYTHON-dev
-    - sudo apt-get install $PYTHON-numpy
-    - sudo apt-get install $PYTHON-scipy
-    - sudo apt-get install $PYTHON-setuptools
-    - sudo apt-get install $PYTHON-nose
-    # Installing sympy for python3 needs pip
-    # The following is an extended virtual line; will be made into one line by
-    # Travis processing.  Avoid `-` at the beginning of the line, remember to
-    # add `;` at the end of continuation lines.
-    - if [ "${PYTHON}" == "python3" ]; then
-        sudo $EASY_INSTALL pip;
-        sudo $PIP install sympy;
-      else
-        sudo apt-get install python-pip python-sympy ;
-      fi
-    - sudo $PIP install nibabel # Latest pypi
-    - $PYTHON setup.py build
-    - sudo $PYTHON setup.py install
+# Multiple lines can be made a single "virtual line" because of the way that
+# Travis munges each line before executing it to print out the exit status.
+# It's okay for it to be on multiple physical lines, so long as you remember:
+# - There can't be any leading "-"s - All newlines will be removed, so use
+# ";"s
+language: python
+python:
+    - 2.6
+    - 3.2
+    - 3.3
+    - 3.4
+matrix:
+  include:
+    - python: 2.7
+      env:
+        - COVERAGE=--with-coverage
+before_install:
+    - sudo apt-get install -qq libatlas-dev libatlas-base-dev gfortran libpng-dev
+    - pip install --no-index -f http://wheels2.astropy.org -f https://nipy.bic.berkeley.edu/scipy_installers/travis scipy matplotlib;
+    - pip install sympy
+    - pip install nibabel
     - if [ "${COVERAGE}" == "--with-coverage" ]; then
-      sudo $PIP install coverage;
-      sudo $PIP install coveralls;
+      pip install coverage;
+      pip install coveralls;
       fi
+# command to install dependencies
+# e.g. pip install -r requirements.txt # --use-mirrors
+install:
+    - python setup.py install
+# command to run tests, e.g. python setup.py test
 script:
     # Change into an innocuous directory and find tests from installation
-    - mkdir for_test
-    - cd for_test
+    - mkdir for_testing
+    - cd for_testing
     - if [ "${COVERAGE}" == "--with-coverage" ]; then cp ../.coveragerc .; fi
-    - $PYTHON ../tools/nipnost $COVERAGE `$PYTHON -c "import os; import nipy; print(os.path.dirname(nipy.__file__))"`
+    - $PYTHON ../tools/nipnost $COVERAGE `python -c "import os; import nipy; print(os.path.dirname(nipy.__file__))"`
 after_success:
     - if [ "${COVERAGE}" == "--with-coverage" ]; then coveralls; fi


### PR DESCRIPTION
We were using erlang as language and apt-get for dependencies, because of the
difficulty getting numpy, scipy onto the travis slaves when using the standard
travis Python virtualenvs.

Now travis has numpy in the virtualenvs, and astropy, nipy.bic have wheels for
the travis slaves, so installation is much quicker.  This commit switches back
to using the travis Python testing machinery.
