### PR TITLE
MRG: fix intermittent errors from Formula

### DIFF
--- a/nipy/algorithms/statistics/formula/formulae.py
+++ b/nipy/algorithms/statistics/formula/formulae.py
@@ -180,13 +180,13 @@ class Term(sympy.Symbol):
 
     def _getformula(self):
         return Formula([self])
-    formula = property(_getformula, doc="Return a Formula with only terms=[self].")
+    formula = property(_getformula,
+                       doc="Return a Formula with only terms=[self].")
 
     def __add__(self, other):
         if self == other:
             return self
-        else:
-            return sympy.Symbol.__add__(self, other)
+        return sympy.Symbol.__add__(self, other)
 
 
 # time symbol
@@ -416,10 +416,10 @@ class Formula(object):
     model being the sum of each term multiplied by a linear regression
     coefficient.
 
-    The expressions may depend on additional Symbol instances,
-    giving a non-linear regression model.
+    The expressions may depend on additional Symbol instances, giving a
+    non-linear regression model.
     """
-    # This flag is defined to avoid using isinstance
+    # This flag is defined for test isformula(obj) instead of isinstance
     _formula_flag = True
 
     def __init__(self, seq, char = 'b'):
@@ -558,10 +558,20 @@ class Formula(object):
         return self.__class__([term.subs(old, new) for term in self.terms])
 
     def __add__(self, other):
-        """
-        Create a new Formula by combining terms
-        of other with those of self.
+        """ New Formula combining terms of `self` with those of `other`.
 
+        Parameters
+        ----------
+        other : Formula instance
+            Object for which ``is_formula(other)`` is True
+
+        Returns
+        -------
+        added : Formula instance
+            Formula combining terms of `self` with terms of `other`
+
+        Examples
+        --------
         >>> x, y, z = [Term(l) for l in 'xyz']
         >>> f1 = Formula([x,y,z])
         >>> f2 = Formula([y])+I
@@ -579,11 +589,23 @@ class Formula(object):
         return f
 
     def __sub__(self, other):
-        """
-        Create a new Formula by deleting terms in other
-        from self. No exceptions are raised for terms in other that do not appear in
-        self.
+        """ Formula from deleting terms in `other` from those in `self`
 
+        No exceptions are raised for terms in `other` that do not appear in
+        `self`.
+
+        Parameters
+        ----------
+        other : Formula instance
+            Object for which ``is_formula(other)`` is True
+
+        Returns
+        -------
+        subbed : Formula instance
+            Formula with terms of `other` removed from terms of `self`
+
+        Examples
+        --------
         >>> x, y, z = [Term(l) for l in 'xyz']
         >>> f1 = Formula([x,y,z])
         >>> f2 = Formula([y])+I
@@ -599,7 +621,8 @@ class Formula(object):
         _b0*x + _b1*z
         """
         if not is_formula(other):
-            raise ValueError('only Formula objects can be subtracted from a Formula')
+            raise ValueError(
+                'only Formula objects can be subtracted from a Formula')
         d = list(set(self.terms).difference(other.terms))
         return self.__class__(d)
 
@@ -638,11 +661,11 @@ class Formula(object):
         return np.alltrue(np.equal(np.array(self), np.array(other)))
 
     def _setup_design(self):
-        """
-        Create a callable object to evaluate the design matrix
-        at a given set of parameter values to be specified by
-        a recarray and observed Term values, also specified
-        by a recarray.
+        """ Initialize design
+
+        Create a callable object to evaluate the design matrix at a given set
+        of parameter values to be specified by a recarray and observed Term
+        values, also specified by a recarray.
         """
         # the design expression is the differentiation of the expression
         # for the mean.  It is a list
@@ -955,16 +978,15 @@ class Factor(Formula):
     _factor_flag = True
 
     def __init__(self, name, levels, char='b'):
-        """
+        """ Initialize Factor
+
         Parameters
         ----------
         name : str
         levels : [str or int]
             A sequence of strings or ints.
-        char : str
-
-        Returns
-        -------
+        char : str, optional
+            prefix character for regression coefficients
         """
         # Check whether they can all be cast to strings or ints without
         # loss.
@@ -1005,9 +1027,9 @@ class Factor(Formula):
 
         Parameters
         ----------
-        variable : str or a simple sympy expression whose string representation
-            are all lower or upper case letters, i.e. it can be interpreted
-            as a name
+        variable : str or simple sympy expression
+            If sympy expression, then string representation must be all lower
+            or upper case letters, i.e. it can be interpreted as a name.
 
         Returns
         -------
@@ -1039,13 +1061,11 @@ class Factor(Formula):
         ----------
         col : ndarray
             an array with ndim==1
-
         name : str
             name of the Factor
 
         Returns
         -------
-
         factor : Factor
 
         Examples

--- a/nipy/algorithms/statistics/formula/formulae.py
+++ b/nipy/algorithms/statistics/formula/formulae.py
@@ -627,7 +627,8 @@ class Formula(object):
             raise ValueError(
                 'only Formula objects can be subtracted from a Formula')
         # Preserve order of terms in subtraction
-        d = [term for term in self.terms if term not in other.terms]
+        unwanted = set(other.terms)
+        d = [term for term in self.terms if term not in unwanted]
         return Formula(d)
 
     def __array__(self):

--- a/nipy/algorithms/statistics/formula/formulae.py
+++ b/nipy/algorithms/statistics/formula/formulae.py
@@ -607,16 +607,16 @@ class Formula(object):
         Examples
         --------
         >>> x, y, z = [Term(l) for l in 'xyz']
-        >>> f1 = Formula([x,y,z])
-        >>> f2 = Formula([y])+I
+        >>> f1 = Formula([x, y, z])
+        >>> f2 = Formula([y]) + I
         >>> f1.mean
         _b0*x + _b1*y + _b2*z
         >>> f2.mean
         _b0*y + _b1
-        >>> f3=f2-f1
+        >>> f3 = f2 - f1
         >>> f3.mean
         _b0
-        >>> f4=f1-f2
+        >>> f4 = f1 - f2
         >>> f4.mean
         _b0*x + _b1*z
         """

--- a/nipy/algorithms/statistics/formula/formulae.py
+++ b/nipy/algorithms/statistics/formula/formulae.py
@@ -623,7 +623,8 @@ class Formula(object):
         if not is_formula(other):
             raise ValueError(
                 'only Formula objects can be subtracted from a Formula')
-        d = list(set(self.terms).difference(other.terms))
+        # Preserve order of terms in subtraction
+        d = [term for term in self.terms if term not in other.terms]
         return Formula(d)
 
     def __array__(self):

--- a/nipy/algorithms/statistics/formula/formulae.py
+++ b/nipy/algorithms/statistics/formula/formulae.py
@@ -585,7 +585,7 @@ class Formula(object):
         """
         if not is_formula(other):
             raise ValueError('only Formula objects can be added to a Formula')
-        f = self.__class__(np.hstack([self.terms, other.terms]))
+        f = Formula(np.hstack([self.terms, other.terms]))
         return f
 
     def __sub__(self, other):
@@ -624,7 +624,7 @@ class Formula(object):
             raise ValueError(
                 'only Formula objects can be subtracted from a Formula')
         d = list(set(self.terms).difference(other.terms))
-        return self.__class__(d)
+        return Formula(d)
 
     def __array__(self):
         return self.terms

--- a/nipy/algorithms/statistics/formula/formulae.py
+++ b/nipy/algorithms/statistics/formula/formulae.py
@@ -589,7 +589,10 @@ class Formula(object):
         return f
 
     def __sub__(self, other):
-        """ Formula from deleting terms in `other` from those in `self`
+        """ New Formula by deleting terms in `other` from those in `self`
+
+        Create and return a new Formula by deleting terms in `other` from those
+        in `self`.
 
         No exceptions are raised for terms in `other` that do not appear in
         `self`.

--- a/nipy/algorithms/statistics/formula/tests/test_formula.py
+++ b/nipy/algorithms/statistics/formula/tests/test_formula.py
@@ -199,6 +199,14 @@ def test_factor_add_sub():
     assert_equal(f1 - f3, f1)
 
 
+def test_term_order_sub():
+    # Test preservation of term order in subtraction
+    f1 = F.Formula(terms('z, y, x, w'))
+    f2 = F.Formula(terms('x, y, a'))
+    assert_array_equal((f1 - f2).terms, terms('z, w'))
+    assert_array_equal((f2 - f1).terms, terms('a'))
+
+
 def test_make_recarray():
     m = F.make_recarray([[3,4],[4,6],[7,9]], 'wv', [np.float, np.int])
     assert_equal(m.dtype.names, ('w', 'v'))

--- a/nipy/algorithms/statistics/formula/tests/test_formula.py
+++ b/nipy/algorithms/statistics/formula/tests/test_formula.py
@@ -43,24 +43,24 @@ def test_terms():
 def test_getparams_terms():
     t = F.Term('t')
     x, y, z = [sympy.Symbol(l) for l in 'xyz']
-    yield assert_equal, set(F.getparams(x*y*t)), set([x,y])
-    yield assert_equal, set(F.getterms(x*y*t)), set([t])
+    assert_equal(set(F.getparams(x*y*t)), set([x,y]))
+    assert_equal(set(F.getterms(x*y*t)), set([t]))
 
     matrix_expr = np.array([[x,y*t],[y,z]])
-    yield assert_equal, set(F.getparams(matrix_expr)), set([x,y,z])
-    yield assert_equal, set(F.getterms(matrix_expr)), set([t])
+    assert_equal(set(F.getparams(matrix_expr)), set([x,y,z]))
+    assert_equal(set(F.getterms(matrix_expr)), set([t]))
 
 
 def test_formula_params():
     t = F.Term('t')
     x, y = [sympy.Symbol(l) for l in 'xy']
     f = F.Formula([t*x,y])
-    yield assert_equal, set(f.params), set([x,y] + list(f.coefs.values()))
+    assert_equal(set(f.params), set([x,y] + list(f.coefs.values())))
 
 
 def test_contrast1():
     x = F.Term('x')
-    yield assert_equal, x, x+x
+    assert_equal(x, x+x)
     y = F.Term('y')
     z = F.Term('z')
     f = F.Formula([x,y])
@@ -69,10 +69,10 @@ def test_contrast1():
                                     'diff':F.Formula([x-y]),
                                     'sum':F.Formula([x+y]),
                                     'both':F.Formula([x-y,x+y])})
-    yield assert_almost_equal, C['x'], np.array([1,0])
-    yield assert_almost_equal, C['diff'], np.array([1,-1])
-    yield assert_almost_equal, C['sum'], np.array([1,1])
-    yield assert_almost_equal, C['both'], np.array([[1,-1],[1,1]])
+    assert_almost_equal(C['x'], np.array([1,0]))
+    assert_almost_equal(C['diff'], np.array([1,-1]))
+    assert_almost_equal(C['sum'], np.array([1,1]))
+    assert_almost_equal(C['both'], np.array([[1,-1],[1,1]]))
 
     f = F.Formula([x,y,z])
     arr = F.make_recarray([[3,5,4],[8,21,-1],[4,6,-2]], 'xyz')
@@ -80,10 +80,10 @@ def test_contrast1():
                                     'diff':F.Formula([x-y]),
                                     'sum':F.Formula([x+y]),
                                     'both':F.Formula([x-y,x+y])})
-    yield assert_almost_equal, C['x'], np.array([1,0,0])
-    yield assert_almost_equal, C['diff'], np.array([1,-1,0])
-    yield assert_almost_equal, C['sum'], np.array([1,1,0])
-    yield assert_almost_equal, C['both'], np.array([[1,-1,0],[1,1,0]])
+    assert_almost_equal(C['x'], np.array([1,0,0]))
+    assert_almost_equal(C['diff'], np.array([1,-1,0]))
+    assert_almost_equal(C['sum'], np.array([1,1,0]))
+    assert_almost_equal(C['both'], np.array([[1,-1,0],[1,1,0]]))
 
 
 def test_formula_from_recarray():
@@ -181,10 +181,10 @@ def test_mul():
     f2 = F.Factor('t', [2,3,4])
     t2 = f['t_2']
     x = F.Term('x')
-    yield assert_equal, t2, t2*t2
-    yield assert_equal, f, f*f
-    yield assert_false, f == f2
-    yield assert_equal, set((t2*x).atoms()), set([t2,x])
+    assert_equal(t2, t2*t2)
+    assert_equal(f, f*f)
+    assert_false(f == f2)
+    assert_equal(set((t2*x).atoms()), set([t2,x]))
 
 
 def test_make_recarray():
@@ -198,7 +198,7 @@ def test_str_formula():
     t1 = F.Term('x')
     t2 = F.Term('y')
     f = F.Formula([t1, t2])
-    yield assert_equal, str(f), "Formula([x, y])"
+    assert_equal(str(f), "Formula([x, y])")
 
 
 def test_design():
@@ -277,13 +277,13 @@ def test_alias():
 
 def test_factor_getterm():
     fac = F.Factor('f', 'ab')
-    yield assert_equal, fac['f_a'], fac.get_term('a')
+    assert_equal(fac['f_a'], fac.get_term('a'))
     fac = F.Factor('f', [1,2])
-    yield assert_equal, fac['f_1'], fac.get_term(1)
+    assert_equal(fac['f_1'], fac.get_term(1))
     fac = F.Factor('f', [1,2])
-    yield assert_raises, ValueError, fac.get_term, '1'
+    assert_raises(ValueError, fac.get_term, '1')
     m = fac.main_effect
-    yield assert_equal, set(m.terms), set([fac['f_1']-fac['f_2']])
+    assert_equal(set(m.terms), set([fac['f_1']-fac['f_2']]))
 
 
 def test_stratify():
@@ -291,7 +291,7 @@ def test_stratify():
 
     y = sympy.Symbol('y')
     f = sympy.Function('f')
-    yield assert_raises, ValueError, fac.stratify, f(y)
+    assert_raises(ValueError, fac.stratify, f(y))
 
 
 def test_nonlin1():
@@ -331,7 +331,7 @@ def test_nonlin2():
     t = sympy.Symbol('th')
     p = F.make_recarray([3], ['tt'])
     f = F.Formula([sympy.exp(t*z)])
-    yield assert_raises, ValueError, f.design, dz, p
+    assert_raises(ValueError, f.design, dz, p)
 
 
 def test_Rintercept():
@@ -348,9 +348,9 @@ def test_return_float():
     f = F.Formula([x,x**2])
     xx= F.make_recarray(np.linspace(0,10,11), 'x')
     dtype = f.design(xx).dtype
-    yield assert_equal, set(dtype.names), set(['x', 'x**2'])
+    assert_equal(set(dtype.names), set(['x', 'x**2']))
     dtype = f.design(xx, return_float=True).dtype
-    yield assert_equal, dtype, np.float
+    assert_equal(dtype, np.float)
 
 
 def test_subtract():
@@ -358,10 +358,10 @@ def test_subtract():
     f1 = F.Formula([x,y])
     f2 = F.Formula([x,y,z])
     f3 = f2 - f1
-    yield assert_equal, set(f3.terms), set([z])
+    assert_equal(set(f3.terms), set([z]))
     f4 = F.Formula([y,z])
     f5 = f1 - f4
-    yield assert_equal, set(f5.terms), set([x])
+    assert_equal(set(f5.terms), set([x]))
 
 
 def test_subs():
@@ -370,7 +370,7 @@ def test_subs():
     z = F.Term('z')
     f = F.Formula([t1, t2])
     g = f.subs(t1, z)
-    yield assert_equal, list(g.terms), [z, t2]
+    assert_equal(list(g.terms), [z, t2])
 
 
 def test_natural_spline():
@@ -380,24 +380,24 @@ def test_natural_spline():
     xx= F.make_recarray(np.linspace(0,10,101), 'x')
     dd=ns.design(xx, return_float=True)
     xx = xx['x']
-    yield assert_almost_equal, dd[:,0], xx
-    yield assert_almost_equal, dd[:,1], xx**2
-    yield assert_almost_equal, dd[:,2], xx**3
-    yield assert_almost_equal, dd[:,3], (xx-2)**3*np.greater_equal(xx,2)
-    yield assert_almost_equal, dd[:,4], (xx-6)**3*np.greater_equal(xx,6)
-    yield assert_almost_equal, dd[:,5], (xx-9)**3*np.greater_equal(xx,9)
+    assert_almost_equal(dd[:,0], xx)
+    assert_almost_equal(dd[:,1], xx**2)
+    assert_almost_equal(dd[:,2], xx**3)
+    assert_almost_equal(dd[:,3], (xx-2)**3*np.greater_equal(xx,2))
+    assert_almost_equal(dd[:,4], (xx-6)**3*np.greater_equal(xx,6))
+    assert_almost_equal(dd[:,5], (xx-9)**3*np.greater_equal(xx,9))
 
     ns=F.natural_spline(xt, knots=[2,9,6], intercept=True)
     xx= F.make_recarray(np.linspace(0,10,101), 'x')
     dd=ns.design(xx, return_float=True)
     xx = xx['x']
-    yield assert_almost_equal, dd[:,0], 1
-    yield assert_almost_equal, dd[:,1], xx
-    yield assert_almost_equal, dd[:,2], xx**2
-    yield assert_almost_equal, dd[:,3], xx**3
-    yield assert_almost_equal, dd[:,4], (xx-2)**3*np.greater_equal(xx,2)
-    yield assert_almost_equal, dd[:,5], (xx-9)**3*np.greater_equal(xx,9)
-    yield assert_almost_equal, dd[:,6], (xx-6)**3*np.greater_equal(xx,6)
+    assert_almost_equal(dd[:,0], 1)
+    assert_almost_equal(dd[:,1], xx)
+    assert_almost_equal(dd[:,2], xx**2)
+    assert_almost_equal(dd[:,3], xx**3)
+    assert_almost_equal(dd[:,4], (xx-2)**3*np.greater_equal(xx,2))
+    assert_almost_equal(dd[:,5], (xx-9)**3*np.greater_equal(xx,9))
+    assert_almost_equal(dd[:,6], (xx-6)**3*np.greater_equal(xx,6))
 
 
 def test_factor_term():

--- a/nipy/algorithms/statistics/formula/tests/test_formula.py
+++ b/nipy/algorithms/statistics/formula/tests/test_formula.py
@@ -187,6 +187,18 @@ def test_mul():
     assert_equal(set((t2*x).atoms()), set([t2,x]))
 
 
+def test_factor_add_sub():
+    # Test adding and subtracting Factors
+    f1 = F.Factor('t', [2, 3, 4])
+    f2 = F.Factor('t', [2, 3])
+    # Terms do not cancel in addition
+    assert_equal(f1 + f2, F.Formula(np.hstack((f1.terms, f2.terms))))
+    assert_equal(f1 - f2, F.Factor('t', [4]))
+    f3 = F.Factor('p', [0, 1])
+    assert_equal(f1 + f3, F.Formula(np.hstack((f1.terms, f3.terms))))
+    assert_equal(f1 - f3, f1)
+
+
 def test_make_recarray():
     m = F.make_recarray([[3,4],[4,6],[7,9]], 'wv', [np.float, np.int])
     assert_equal(m.dtype.names, ('w', 'v'))


### PR DESCRIPTION
Closes gh-258.

Intermittent errors testing Formula, turned out to be from:

* An error I introduced trying to make it easier to use sub-classes with
  Formula add and subtract;
* Unpredictable order of terms after subtraction, caused by use of set to find
  unique terms.