### PR TITLE
diag = >diag.copy() when the matrix will be manipulated.

### DIFF
--- a/nipy/labs/viz_tools/maps_3d.py
+++ b/nipy/labs/viz_tools/maps_3d.py
@@ -56,13 +56,13 @@ def affine_img_src(data, affine, scale=1, name='AffineImage',
         # Try out old install of Mayavi, with namespace packages
         from enthought.mayavi.sources.api import ArraySource
     center = np.r_[0, 0, 0, 1]
-    spacing = np.diag(affine)[:3]
+    spacing = np.diag(affine)[:3].copy()
     origin = np.dot(affine, center)[:3]
     if reverse_x:
         # Radiologic convention
         spacing[0] *= -1
         origin[0] *= -1
-    src = ArraySource(scalar_data=np.asarray(data, dtype=np.float), 
+    src = ArraySource(scalar_data=np.asarray(data, dtype=np.float),
                            name=name,
                            spacing=scale*spacing,
                            origin=scale*origin)


### PR DESCRIPTION
This is a general fix for #325 . In the newest version of `numpy`, when `diag` returns a vector of numbers along the diagonal, that vector is read-only. In places where we wish to manipulate the elements of that vector, we need to call `copy()` first.

I manually went through to check each call to `diag`, and to see where we manipulated the elements or returned the vector value.

**Questions:**

* Do we have tests that use `numpy==1.9`? 
* Do we want to add a specific plotting regression for #325?
