### PR TITLE
BF: fix bug in writing PCA time-courses

### DIFF
--- a/nipy/algorithms/diagnostics/screens.py
+++ b/nipy/algorithms/diagnostics/screens.py
@@ -135,7 +135,8 @@ def write_screen_res(res, out_path, out_root,
                                              out_img_ext))
         save_image(res[key], fname)
     # plot, save component time courses and some tsdiffana stuff
-    ncomp = res['pca_res']['axis']
+    pca_axis = res['pca_res']['axis']
+    n_comp = res['pca_res']['basis_projections'].shape[pca_axis]
     vectors = res['pca_res']['basis_vectors']
     pcnt_var = res['pca_res']['pcnt_var']
     np.savez(pjoin(out_path, 'vectors_components_%s.npz' % out_root),
@@ -145,8 +146,8 @@ def write_screen_res(res, out_path, out_root,
              slice_mean_diff2=res['ts_res']['slice_mean_diff2'],
             )
     plt.figure()
-    for c in range(ncomp):
-        plt.subplot(ncomp, 1, c+1)
+    for c in range(n_comp):
+        plt.subplot(n_comp, 1, c+1)
         plt.plot(vectors[:,c])
         plt.axis('tight')
     plt.suptitle(out_root + ': PCA basis vectors')


### PR DESCRIPTION
We were using the axis number of the PCA analysis (usually axis index 3, time)
as the number of components (by default, 10).  Fix.

I've tested this at the command line with matplotlib, but it's hard to test
automatically without doing some image comparison test, and that seems like a
lot of work.