### PR TITLE
MAINT: rewrite long description; fill README.rst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,4 +139,7 @@ website-stamp: $(WWW_DIR) html-stamp pdf-stamp
 upload-html: html-stamp
 	./tools/upload-gh-pages.sh $(WWW_DIR) $(PROJECT)
 
+refresh-readme:
+	$(PYTHON) tools/refresh_readme.py nipy
+
 .PHONY: orig-src pylint

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,11 @@
 .. -*- rest -*-
-.. vim:syntax=rest
+.. vim:syntax=rst
+
+.. image:: https://coveralls.io/repos/nipy/nipy/badge.png?branch=master
+    :target: https://coveralls.io/r/nipy/nipy?branch=master
+
+.. Following contents should be from LONG_DESCRIPTION in nipy/info.py
+
 
 ====
 NIPY
@@ -7,37 +13,37 @@ NIPY
 
 Neuroimaging tools for Python.
 
-The aim of NIPY is to produce a platform-independent Python environment for the
-analysis of functional brain imaging data using an open development model.
+The aim of NIPY is to produce a platform-independent Python environment for
+the analysis of functional brain imaging data using an open development model.
 
 In NIPY we aim to:
 
-1. Provide an open source, mixed language scientific programming
-    environment suitable for rapid development.
+1. Provide an open source, mixed language scientific programming environment
+   suitable for rapid development.
 
-2. Create sofware components in this environment to make it easy
-    to develop tools for MRI, EEG, PET and other modalities.
+2. Create software components in this environment to make it easy to develop
+   tools for MRI, EEG, PET and other modalities.
 
-3. Create and maintain a wide base of developers to contribute to
-    this platform.
+3. Create and maintain a wide base of developers to contribute to this
+   platform.
 
-4. To maintain and develop this framework as a single, easily
-    installable bundle.
+4. To maintain and develop this framework as a single, easily installable
+   bundle.
 
-NIPY is the work of many people. We list the main authors in the file ``AUTHOR``
-in the NIPY distribution, and other contributions in ``THANKS``.
+NIPY is the work of many people. We list the main authors in the file
+``AUTHOR`` in the NIPY distribution, and other contributions in ``THANKS``.
 
 Website
 =======
 
-Current information can always be found at the NIPY website::
-
-    http://nipy.org/nipy
+Current information can always be found at the `NIPY project website
+<http://nipy.org/nipy>`_.
 
 Mailing Lists
 =============
 
-For questions on how to use nipy or on making code contributions, please see the ``neuroimaging`` mailing list:
+For questions on how to use nipy or on making code contributions, please see
+the ``neuroimaging`` mailing list:
 
     https://mail.python.org/mailman/listinfo/neuroimaging
 
@@ -54,14 +60,14 @@ Code
 
 You can find our sources and single-click downloads:
 
-* `Main repository`_ on Github.
-* Documentation_ for all releases and current development tree.
-* Download as a tar/zip file the `current trunk`_.
+* `Main repository`_ on Github;
+* Documentation_ for all releases and current development tree;
+* Download the `current development version`_ as a tar/zip file;
 * Downloads of all `available releases`_.
 
 .. _main repository: http://github.com/nipy/nipy
 .. _Documentation: http://nipy.org/nipy
-.. _current trunk: http://github.com/nipy/nipy/archives/master
+.. _current development version: https://github.com/nipy/nipy/archive/master.zip
 .. _available releases: http://pypi.python.org/pypi/nipy
 
 Dependencies
@@ -69,10 +75,10 @@ Dependencies
 
 To run NIPY, you will need:
 
-* python_ >= 2.5 (tested with 2.5, 2.6, 2.7, 3.2, 3.3)
-* numpy_ >= 1.2
+* python_ >= 2.6 (tested with 2.6, 2.7, 3.2, 3.3, 3.4)
+* numpy_ >= 1.6.0
 * scipy_ >= 0.7.0
-* sympy_ >= 0.6.6
+* sympy_ >= 0.7.0
 * nibabel_ >= 1.2
 
 You will probably also like to have:
@@ -86,12 +92,12 @@ You will probably also like to have:
 .. _scipy: http://www.scipy.org
 .. _sympy: http://sympy.org
 .. _nibabel: http://nipy.org/nibabel
-.. _ipython: http://ipython.scipy.org
-.. _matplotlib: http://matplotlib.sourceforge.net
+.. _ipython: http://ipython.org
+.. _matplotlib: http://matplotlib.org
 .. _mayavi: http://code.enthought.com/projects/mayavi/
 
 License
 =======
 
-We use the 3-clause BSD license; the full license is in the file ``LICENSE`` in
-the nipy distribution.
+We use the 3-clause BSD license; the full license is in the file ``LICENSE``
+in the nipy distribution.

--- a/doc/devel/guidelines/make_release.rst
+++ b/doc/devel/guidelines/make_release.rst
@@ -62,6 +62,20 @@ Release checklist
 
 * Check the copyright years in ``doc/conf.py`` and ``LICENSE``
 
+* Refresh the ``REAMDE.rst`` text from the ``LONG_DESCRIPTION`` in ``info.py``
+  by running ``make refresh-readme``.
+
+  Check the output of::
+
+    rst2html.py README.rst > ~/tmp/readme.html
+
+  because this will be the output used by pypi_
+
+* Check the dependencies listed in ``nipy/info.py`` (e.g.
+  ``NUMPY_MIN_VERSION``) and in ``doc/installation.rst``.  They should
+  at least match. Do they still hold?  Make sure ``.travis.yml`` is testing
+  these minimum dependencies specifically.
+
 * Check the examples in python 2 and python 3, by running something like::
 
     cd ..
@@ -71,9 +85,6 @@ Release checklist
   ``~/tmp/eg_logs``. The output file ``summary.txt`` will have the pass file
   printout that the ``run_log_examples.py`` script puts onto stdout while
   running.
-
-* Check the ``long_description`` in ``nipy/info.py``.  Check it matches the
-  ``README`` in the root directory, maybe with ``vim`` ``diffthis`` command.
 
 * Do a final check on the `nipy buildbot`_
 

--- a/nipy/info.py
+++ b/nipy/info.py
@@ -28,9 +28,9 @@ CLASSIFIERS = ["Development Status :: 3 - Alpha",
 
 description  = 'A python package for analysis of neuroimaging data'
 
-# Note: this long_description is actually a copy/paste from the top-level
-# README.rst, so that it shows up nicely on PyPI.  So please remember to edit
-# it only in one place and sync it correctly.
+# Note: this long_description is the canonical place to edit this text.
+# It also appears in README.rst, but it should get there by running
+# ``tools/refresh_readme.py`` which pulls in this version.
 long_description = \
 """
 ====
@@ -39,53 +39,61 @@ NIPY
 
 Neuroimaging tools for Python.
 
-The aim of NIPY is to produce a platform-independent Python environment for the
-analysis of functional brain imaging data using an open development model.
+The aim of NIPY is to produce a platform-independent Python environment for
+the analysis of functional brain imaging data using an open development model.
 
 In NIPY we aim to:
 
-1. Provide an open source, mixed language scientific programming
-    environment suitable for rapid development.
+1. Provide an open source, mixed language scientific programming environment
+   suitable for rapid development.
 
-2. Create sofware components in this environment to make it easy
-    to develop tools for MRI, EEG, PET and other modalities.
+2. Create software components in this environment to make it easy to develop
+   tools for MRI, EEG, PET and other modalities.
 
-3. Create and maintain a wide base of developers to contribute to
-    this platform.
+3. Create and maintain a wide base of developers to contribute to this
+   platform.
 
-4. To maintain and develop this framework as a single, easily
-    installable bundle.
+4. To maintain and develop this framework as a single, easily installable
+   bundle.
 
-NIPY is the work of many people. We list the main authors in the file ``AUTHOR``
-in the NIPY distribution, and other contributions in ``THANKS``.
+NIPY is the work of many people. We list the main authors in the file
+``AUTHOR`` in the NIPY distribution, and other contributions in ``THANKS``.
 
 Website
 =======
 
-Current information can always be found at the NIPY website::
-
-    http://nipy.org/nipy
+Current information can always be found at the `NIPY project website
+<http://nipy.org/nipy>`_.
 
 Mailing Lists
 =============
 
-Please see the developer's list::
+For questions on how to use nipy or on making code contributions, please see
+the ``neuroimaging`` mailing list:
 
-    http://projects.scipy.org/mailman/listinfo/nipy-devel
+    https://mail.python.org/mailman/listinfo/neuroimaging
+
+Please report bugs at github issues:
+
+    https://github.com/nipy/nipy/issues
+
+You can see the list of current proposed changes at:
+
+    https://github.com/nipy/nipy/pulls
 
 Code
 ====
 
 You can find our sources and single-click downloads:
 
-* `Main repository`_ on Github.
-* Documentation_ for all releases and current development tree.
-* Download as a tar/zip file the `current trunk`_.
+* `Main repository`_ on Github;
+* Documentation_ for all releases and current development tree;
+* Download the `current development version`_ as a tar/zip file;
 * Downloads of all `available releases`_.
 
 .. _main repository: http://github.com/nipy/nipy
 .. _Documentation: http://nipy.org/nipy
-.. _current trunk: http://github.com/nipy/nipy/archives/master
+.. _current development version: https://github.com/nipy/nipy/archive/master.zip
 .. _available releases: http://pypi.python.org/pypi/nipy
 
 Dependencies
@@ -110,16 +118,25 @@ You will probably also like to have:
 .. _scipy: http://www.scipy.org
 .. _sympy: http://sympy.org
 .. _nibabel: http://nipy.org/nibabel
-.. _ipython: http://ipython.scipy.org
-.. _matplotlib: http://matplotlib.sourceforge.net
+.. _ipython: http://ipython.org
+.. _matplotlib: http://matplotlib.org
 .. _mayavi: http://code.enthought.com/projects/mayavi/
 
 License
 =======
 
-We use the 3-clause BSD license; the full license is in the file ``LICENSE`` in
-the nipy distribution.
+We use the 3-clause BSD license; the full license is in the file ``LICENSE``
+in the nipy distribution.
 """
+
+# minimum versions
+# Update in readme text above
+NUMPY_MIN_VERSION='1.6.0'
+SCIPY_MIN_VERSION = '0.7.0'
+NIBABEL_MIN_VERSION = '1.2'
+SYMPY_MIN_VERSION = '0.7.0'
+MAYAVI_MIN_VERSION = '3.0'
+CYTHON_MIN_VERSION = '0.12.1'
 
 NAME                = 'nipy'
 MAINTAINER          = "nipy developers"
@@ -140,15 +157,6 @@ ISRELEASE           = _version_extra == ''
 VERSION             = __version__
 REQUIRES            = ["numpy", "scipy", "sympy", "nibabel"]
 STATUS              = 'beta'
-
-# versions
-# Update in readme text above
-NUMPY_MIN_VERSION='1.6.0'
-SCIPY_MIN_VERSION = '0.7.0'
-NIBABEL_MIN_VERSION = '1.2'
-SYMPY_MIN_VERSION = '0.7.0'
-MAYAVI_MIN_VERSION = '3.0'
-CYTHON_MIN_VERSION = '0.12.1'
 
 # Versions and locations of optional data packages
 NIPY_DATA_URL= 'http://nipy.org/data-packages/'

--- a/tools/refresh_readme.py
+++ b/tools/refresh_readme.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+""" Refresh README.rst file from long description
+
+Should be run from project root (containing setup.py)
+"""
+from __future__ import print_function
+
+import os
+import sys
+
+
+def main():
+    project_name = sys.argv[1]
+    readme_lines = []
+    with open('README.rst', 'rt') as fobj:
+        for line in fobj:
+            readme_lines.append(line)
+            if line.startswith('.. Following contents should be'):
+                break
+        else:
+            raise ValueError('Expected comment not found')
+
+    rel = {}
+    with open(os.path.join(project_name, 'info.py'), 'rt') as fobj:
+        exec(fobj.read(), {}, rel)
+
+    readme = ''.join(readme_lines) + '\n' + rel['LONG_DESCRIPTION']
+
+    with open('README.rst', 'wt') as fobj:
+        fobj.write(readme)
+
+    print('Done')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Rewrite long description, with correct dependencies.

Port over the nibabel machinery for filling the README.rst file from the
long description.

Note this in the release notes.