### PR TITLE
MRG: hack to work round np.intp bug in ndimage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     # Absolute minimum dependencies
     - python: 2.7
       env:
-        - DEPENDS="numpy==1.6.0 scipy==0.7.0 sympy==0.7.0 nibabel==1.2.0"
+        - DEPENDS="numpy==1.6.0 scipy==0.9.0 sympy==0.7.0 nibabel==1.2.0"
     # Test compiling against external lapack
     - python: 3.4
       env:

--- a/nipy/algorithms/interpolation.py
+++ b/nipy/algorithms/interpolation.py
@@ -11,6 +11,8 @@ import numpy as np
 
 from scipy import ndimage
 
+from ..fixes.scipy.ndimage import map_coordinates
+
 class ImageInterpolator(object):
     """ Interpolate Image instance at arbitrary points in world space
 
@@ -89,12 +91,12 @@ class ImageInterpolator(object):
         points.shape = (points.shape[0], np.product(output_shape))
         cmapi = self.image.coordmap.inverse()
         voxels = cmapi(points.T).T
-        V = ndimage.map_coordinates(self.data,
-                                     voxels,
-                                     order=self.order,
-                                     mode=self.mode,
-                                     cval=self.cval,
-                                     prefilter=False)
+        V = map_coordinates(self.data,
+                            voxels,
+                            order=self.order,
+                            mode=self.mode,
+                            cval=self.cval,
+                            prefilter=False)
         # ndimage.map_coordinates returns a flat array,
         # it needs to be reshaped to the original shape
         V.shape = output_shape

--- a/nipy/algorithms/registration/resample.py
+++ b/nipy/algorithms/registration/resample.py
@@ -3,7 +3,9 @@ from __future__ import absolute_import
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
 import numpy as np
-from scipy.ndimage import affine_transform, map_coordinates
+
+from ...fixes.scipy.ndimage import affine_transform, map_coordinates
+
 from nibabel.casting import shared_range
 
 from ...core.image.image_spaces import (make_xyz_image,

--- a/nipy/algorithms/resample.py
+++ b/nipy/algorithms/resample.py
@@ -8,7 +8,7 @@ import copy
 
 import numpy as np
 
-from scipy.ndimage import affine_transform
+from ..fixes.scipy.ndimage import affine_transform
 
 from nibabel.affines import from_matvec, to_matvec
 

--- a/nipy/fixes/scipy/__init__.py
+++ b/nipy/fixes/scipy/__init__.py
@@ -1,0 +1,1 @@
+# Make scipy fixes a package

--- a/nipy/fixes/scipy/ndimage/__init__.py
+++ b/nipy/fixes/scipy/ndimage/__init__.py
@@ -1,0 +1,87 @@
+""" Patches for scipy.ndimage
+
+Patched affine_transform to work round np.intp bug.
+
+Some versions of scipy.ndimage interpolation routines can't handle the np.intp
+type. I (MB) have only seen this on a 32-bit machine runing scipy 0.9.0
+"""
+
+import numpy as np
+
+import scipy.ndimage as spnd
+
+# int dtype corresponding to intp
+_INT_DTYPE = np.dtype(np.int32 if np.dtype(np.intp).itemsize == 4 else
+                      np.int64)
+
+
+# Do not run doctests on this module via nose; scipy doctests unreliable
+__test__ = False
+
+
+def _proc_array(array):
+    """ Change array dtype from intp to int32 / int64
+
+    Parameters
+    ----------
+    array : ndarray
+
+    Returns
+    -------
+    output_array : ndarray
+        `array` unchanged or view of array where array dtype has been changed
+        from ``np.intp`` to ``np.int32`` or ``np.int64`` depending on whether
+        this is a 32 or 64 bit numpy.  All other dtypes unchanged.
+    """
+    if array.dtype == np.dtype(np.intp):
+        return array.view(_INT_DTYPE)
+    return array
+
+
+def _proc_output(output):
+    """ Change dtype from intp to int32 / int64 for ndimage output parameter
+
+    Allowed values to `output` are the same as listed for the ``output``
+    parameter to ``scipy.ndimage.affine_transform``.
+
+    Parameters
+    ----------
+    output : None or ndarray or or dtype or dtype specifier
+        Can be ndarray (will have ``.dtype`` attribute), or a numpy dtype, or
+        something that can be converted to a numpy dtype such as a string dtype
+        code or numpy type.
+
+    Returns
+    -------
+    output_fixed : None or ndarray or dtype or dtype specifier
+        `output` where array dtype or dtype specifier has been changed from
+        ``np.intp`` to ``np.int32`` or ``np.int64`` depending on whether this
+        is a 32 or 64 bit numpy.  All other dtypes unchanged.  None returned
+        unchanged
+    """
+    if output is None:
+        return None
+    if hasattr(output, 'dtype'):  # output was ndarray
+        return _proc_array(output)
+    # output can also be a dtype specifier
+    if np.dtype(output) == np.dtype(np.intp):  # dtype specifier for np.intp
+        return _INT_DTYPE
+    return output
+
+
+def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
+                     order=3, mode='constant', cval=0.0, prefilter=True):
+    return spnd.affine_transform(_proc_array(input), matrix, offset,
+                                 output_shape, _proc_output(output), order,
+                                 mode, cval, prefilter)
+
+affine_transform.__doc__ = spnd.affine_transform.__doc__
+
+
+def map_coordinates(input, coordinates, output=None, order=3,
+                    mode='constant', cval=0.0, prefilter=True):
+    return spnd.map_coordinates(_proc_array(input), coordinates,
+                                _proc_output(output), order, mode, cval,
+                                prefilter)
+
+map_coordinates.__doc__ = spnd.map_coordinates.__doc__

--- a/nipy/fixes/setup.py
+++ b/nipy/fixes/setup.py
@@ -8,6 +8,8 @@ def configuration(parent_package='',top_path=None):
     config.add_subpackage('numpy')
     config.add_subpackage('numpy.testing')
     config.add_subpackage('nibabel')
+    config.add_subpackage('scipy')
+    config.add_subpackage('scipy.ndimage')
     return config
 
 

--- a/nipy/info.py
+++ b/nipy/info.py
@@ -103,7 +103,7 @@ To run NIPY, you will need:
 
 * python_ >= 2.6 (tested with 2.6, 2.7, 3.2, 3.3, 3.4)
 * numpy_ >= 1.6.0
-* scipy_ >= 0.7.0
+* scipy_ >= 0.9.0
 * sympy_ >= 0.7.0
 * nibabel_ >= 1.2
 
@@ -132,7 +132,7 @@ in the nipy distribution.
 # minimum versions
 # Update in readme text above
 NUMPY_MIN_VERSION='1.6.0'
-SCIPY_MIN_VERSION = '0.7.0'
+SCIPY_MIN_VERSION = '0.9.0'
 NIBABEL_MIN_VERSION = '1.2'
 SYMPY_MIN_VERSION = '0.7.0'
 MAYAVI_MIN_VERSION = '3.0'


### PR DESCRIPTION
Scipy ndimage, at least for scipy 0.9.0, fails when trying to interpolate data
of type np.intp, on a 32-bit system we are testing on:

http://nipy.bic.berkeley.edu/builders/nipy-py2.6-32/builds/291/steps/shell_6/logs/stdio

The interpolation failure gives an error like this:

```
File "/usr/lib/python2.7/dist-packages/scipy/ndimage/interpolation.py", line 392, in affine_transform
    output, order, mode, cval, None, None)
    RuntimeError: data type not supported
```

In fact, the numpy types np.int32 and np.intp (on 32-bits) are the same 32-bit
signed integer types, so we can just view the data as np.int32 (on 32 bits)
before running the ndimage routines.

Write wrappers around `affine_transform` and `map_coordinates` to do this
conversion, and extend tests.

The tests raise some errors on very old scipy, so update scipy dependency to
0.9.0.