### PR TITLE
MRG: rewritten, extended fix for reg script affine

### DIFF
--- a/nipy/algorithms/registration/scripting.py
+++ b/nipy/algorithms/registration/scripting.py
@@ -23,6 +23,8 @@ if HAVE_MPL:
 from .groupwise_registration import SpaceTimeRealign
 import nipy.externals.argparse as argparse
 import nipy.algorithms.slicetiming as st
+from nipy.io.api import save_image
+
 timefuncs = st.timefuncs.SLICETIME_FUNCTIONS
 
 __all__ = ["space_time_realign", "aff2euler"]
@@ -161,20 +163,16 @@ def space_time_realign(input, tr, slice_order='descending', slice_dim=2,
     if apply:
         new_reggy = reggy.resample(align_runs=True)
         for run_idx, new_im in enumerate(new_reggy):
-            new_data = new_im.get_data()
-            # We use the top 4 by 4 as the affine for the new file we will
-            # create:
-            new_aff = new_im.affine[:4, :4]
-            new_ni = nib.Nifti1Image(new_data, new_aff)
             # Save it out to a '.nii.gz' file:
             old_fname_split = op.split(fnames[run_idx])
-            # We retain the file-name adding '_mc' regardless of where it's saved
+            # We retain the file-name adding '_mc' regardless of where it's
+            # saved
             new_fname = old_fname_split[1].split('.')[0] + '_mc.nii.gz'
             if out_name is None:
-                new_path = old_fname_split[0]                               
+                new_path = old_fname_split[0]
             else:
                 new_path = out_name
-            new_ni.to_filename(op.join(new_path, new_fname))
+            save_image(new_im, op.join(new_path, new_fname))
 
     if make_figure:
         figure, ax = plt.subplots(2)

--- a/nipy/algorithms/registration/tests/test_scripting.py
+++ b/nipy/algorithms/registration/tests/test_scripting.py
@@ -1,21 +1,41 @@
-from __future__ import absolute_import
 #!/usr/bin/env python
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
+from __future__ import absolute_import
+
+from os.path import split as psplit
 
 import numpy as np
-import numpy.testing as npt
 
-from nibabel.tmpdirs import InTemporaryDirectory
 import nibabel.eulerangles as euler
 
-from nipy.testing import funcfile
+from nipy.io.api import load_image, save_image
 import nipy.algorithms.registration as reg
+
+from nose.tools import assert_true, assert_false
+
+import numpy.testing as npt
+
+from nipy.testing import funcfile
+
+from nibabel.tmpdirs import InTemporaryDirectory
 
 
 def test_space_time_realign():
-    with InTemporaryDirectory() as tmpdir:
-        xform = reg.space_time_realign(funcfile, 2.0, out_name='./')
+    path, fname = psplit(funcfile)
+    original_affine = load_image(funcfile).affine
+    path, fname = psplit(funcfile)
+    froot, _ = fname.split('.', 1)
+    with InTemporaryDirectory():
+        # Make another image with .nii extension and extra dot in filename
+        save_image(load_image(funcfile), 'my.test.nii')
+        for in_fname, out_fname in ((funcfile, froot + '_mc.nii.gz'),
+                                    ('my.test.nii', 'my.test_mc.nii.gz')):
+            xforms = reg.space_time_realign(in_fname, 2.0, out_name='.')
+            assert_true(np.allclose(xforms[0].as_affine(), np.eye(4), atol=1e-7))
+            assert_false(np.allclose(xforms[-1].as_affine(), np.eye(4), atol=1e-3))
+            img = load_image(out_fname)
+            npt.assert_almost_equal(original_affine, img.affine)
 
 
 def test_aff2euler():


### PR DESCRIPTION
A rewrite and extension of the PR https://github.com/nipy/nipy/pull/317

Adds more general handling of affine, writing of the TR into the affine, and
more general handling of filenames with dots in them.