### PR TITLE
test_olsR: use assert_array_almost_equal instead

### DIFF
--- a/nipy/algorithms/statistics/models/tests/test_olsR.py
+++ b/nipy/algorithms/statistics/models/tests/test_olsR.py
@@ -148,9 +148,9 @@ def test_results():
     M = np.identity(14)
     M = np.array([M[i] for i in [0,1,2,3,4,5,6,8,9,10,11,12,13]])
     Fc = r.Fcontrast(M)
-    yield niptest.assert_almost_equal, Fc.F, f['F'], 6
-    yield niptest.assert_almost_equal, Fc.df_num, f['df_num'], 6
-    yield niptest.assert_almost_equal, Fc.df_den, f['df_den'], 6
+    yield niptest.assert_array_almost_equal, [Fc.F], [f['F']], 6
+    yield niptest.assert_array_almost_equal, [Fc.df_num], [f['df_num']], 6
+    yield niptest.assert_array_almost_equal, [Fc.df_den], [f['df_den']], 6
 
     thetas = []
     sds = []


### PR DESCRIPTION
due to bug in numpy

Related: https://github.com/numpy/numpy/issues/5200