### PR TITLE
BF: fix shebang lines for scripts

### DIFF
--- a/scripts/nipy_3dto4d
+++ b/scripts/nipy_3dto4d
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!python
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 DESCRIP = 'Read 3D image files and write a 4D file'

--- a/scripts/nipy_4d_realign
+++ b/scripts/nipy_4d_realign
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!python
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 

--- a/scripts/nipy_4dto3d
+++ b/scripts/nipy_4dto3d
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!python
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 DESCRIP = 'Read 4D image file and write 3D nifti file for each volume'

--- a/scripts/nipy_diagnose
+++ b/scripts/nipy_diagnose
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!python
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 DESCRIP = 'Calculate and write results for diagnostic screen'

--- a/scripts/nipy_tsdiffana
+++ b/scripts/nipy_tsdiffana
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!python
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 DESCRIP = ' Analyze, plot time series difference metrics'


### PR DESCRIPTION
Shebang lines should be "!python" in order for setuptools / pip to
rewrite the shebangs when installing.

Fixes errors on Python 3.5 e.g.
http://nipy.bic.berkeley.edu/builders/nipy-bdist32-35/builds/6/steps/shell_10/logs/stdio