### PR TITLE
MRG: drop threshold for scipy 0.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
         - INSTALL_TYPE="setup"
 python:
     - 2.6
-    - 3.2
     - 3.3
     - 3.4
     - 3.5

--- a/nipy/algorithms/statistics/models/tests/test_olsR.py
+++ b/nipy/algorithms/statistics/models/tests/test_olsR.py
@@ -148,7 +148,8 @@ def test_results():
     M = np.identity(14)
     M = np.array([M[i] for i in [0,1,2,3,4,5,6,8,9,10,11,12,13]])
     Fc = r.Fcontrast(M)
-    yield niptest.assert_array_almost_equal, [Fc.F], [f['F']], 6
+    # Scipy 0.17.0 gives about 2e-5 difference in this next comparison.
+    yield niptest.assert_true, np.allclose(Fc.F, f['F'])
     yield niptest.assert_array_almost_equal, [Fc.df_num], [f['df_num']], 6
     yield niptest.assert_array_almost_equal, [Fc.df_den], [f['df_den']], 6
 


### PR DESCRIPTION
It looks like scipy 0.17 linalg.lstsq (therefore pinv) has slightly different
precision than previous versions.  The differences in the pseudoinverse are
small, in the region of 1e-13 for a pseudoinverse of a matrix that is not very
close to singular.

See: https://mail.scipy.org/pipermail/scipy-dev/2016-March/021265.html