### PR TITLE
MRG: fix error using interp1d in sympy 1.0

### DIFF
--- a/nipy/modalities/fmri/utils.py
+++ b/nipy/modalities/fmri/utils.py
@@ -33,6 +33,28 @@ from nipy.algorithms.statistics.formula.formulae import Term, Formula
 
 T = Term('t')
 
+
+class Interp1dNumeric(interp1d):
+    """ Wrapper for interp1 to raise TypeError for object array input
+
+    We need this because sympy will try to evaluate interpolated functions when
+    constructing expressions involving floats.  At least sympy 1.0 only accepts
+    TypeError or AttributeError as indication that the implemented value cannot
+    be sampled with the sympy expression.  Therefore, raise a TypeError
+    directly for an input giving an object array (such as a sympy expression),
+    rather than letting interp1d raise a ValueError.
+
+    See:
+
+    * https://github.com/nipy/nipy/issues/395
+    * https://github.com/sympy/sympy/issues/10810
+    """
+    def __call__(self, x):
+        if np.asarray(x).dtype.type == np.object_:
+            raise TypeError('Object arrays not supported')
+        return super(Interp1dNumeric, self).__call__(x)
+
+
 def lambdify_t(expr):
     ''' Return sympy function of t `expr` lambdified as function of t
 
@@ -173,7 +195,7 @@ def interp(times, values, fill=0, name=None, **kw):
             raise ValueError('fill conflicts with fill_value')
         kw['bounds_error'] = False
         kw['fill_value'] = fill
-    interpolator = interp1d(times, values, **kw)
+    interpolator = Interp1dNumeric(times, values, **kw)
     # make a new name if none provided
     if name is None:
         name = 'interp%d' % interp.counter


### PR DESCRIPTION
Closes gh-395.

See https://github.com/sympy/sympy/pull/10874 for a detailed description of the problem and merged sympy PR.

