### PR TITLE
MRG: prefer numpy pinv to scipy pinv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
         - INSTALL_TYPE="setup"
 python:
     - 2.6
-    - 3.2
     - 3.3
     - 3.4
     - 3.5

--- a/nipy/algorithms/statistics/models/nlsmodel.py
+++ b/nipy/algorithms/statistics/models/nlsmodel.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 __docformat__ = 'restructuredtext'
 
 import numpy as np
-import scipy.linalg as spl
+import numpy.linalg as npl
 
 from .model import Model
 
@@ -145,7 +145,7 @@ class NLSModel(Model, Iterator):
         if self._iter < self.niter:
             self.getZ()
             self.getomega()
-            Zpinv = spl.pinv(self._Z)
+            Zpinv = npl.pinv(self._Z)
             self.theta = np.dot(Zpinv, self.Y - self._omega)
         else:
             raise StopIteration

--- a/nipy/algorithms/statistics/models/regression.py
+++ b/nipy/algorithms/statistics/models/regression.py
@@ -25,6 +25,7 @@ __docformat__ = 'restructuredtext en'
 import warnings
 
 import numpy as np
+import numpy.linalg as npl
 
 from scipy import stats
 import scipy.linalg as spl
@@ -105,7 +106,7 @@ class OLSModel(LikelihoodModel):
         # TODO: handle case for noconstant regression
         self.design = design
         self.wdesign = self.whiten(self.design)
-        self.calc_beta = spl.pinv(self.wdesign)
+        self.calc_beta = npl.pinv(self.wdesign)
         self.normalized_cov_beta = np.dot(self.calc_beta,
                                           np.transpose(self.calc_beta))
         self.df_total = self.wdesign.shape[0]
@@ -831,7 +832,7 @@ class GLSModel(OLSModel):
     """
 
     def __init__(self, design, sigma):
-        self.cholsigmainv = spl.linalg.cholesky(spl.linalg.pinv(sigma)).T
+        self.cholsigmainv = npl.cholesky(npl.pinv(sigma)).T
         super(GLSModel, self).__init__(design)
 
     def whiten(self, Y):

--- a/nipy/algorithms/utils/pca.py
+++ b/nipy/algorithms/utils/pca.py
@@ -16,7 +16,7 @@ covariance matrix.
 from __future__ import absolute_import
 
 import numpy as np
-import scipy.linalg as spl
+import numpy.linalg as npl
 
 from ...core.image.image import rollimg
 from ...core.reference.coordinate_map import (io_axis_indices, orth_axes,
@@ -131,7 +131,7 @@ def pca(data, axis=0, mask=None, ncomp=None, standardize=True,
     elif design_resid is None:
         def project_resid(Y): return Y
     else: # matrix passed, we hope
-        projector = np.dot(design_resid, spl.pinv(design_resid))
+        projector = np.dot(design_resid, npl.pinv(design_resid))
         def project_resid(Y):
             return Y - np.dot(projector, Y)
     if standardize:
@@ -157,9 +157,9 @@ def pca(data, axis=0, mask=None, ncomp=None, standardize=True,
     if design_keep is None:
         X = np.eye(data.shape[0])
     else:
-        X = np.dot(design_keep, spl.pinv(design_keep))
+        X = np.dot(design_keep, npl.pinv(design_keep))
     XZ = project_resid(X)
-    UX, SX, VX = spl.svd(XZ, full_matrices=0)
+    UX, SX, VX = npl.svd(XZ, full_matrices=0)
     # The matrix UX has orthonormal columns and represents the
     # final "column space" that the data will be projected onto.
     rank = (SX/SX.max() > tol_ratio).sum()
@@ -170,7 +170,7 @@ def pca(data, axis=0, mask=None, ncomp=None, standardize=True,
     C_full_rank  = _get_covariance(data, UX, rmse_scales_func, mask)
     # find the eigenvalues D and eigenvectors Vs of the covariance
     # matrix
-    D, Vs = spl.eigh(C_full_rank)
+    D, Vs = npl.eigh(C_full_rank)
     # Compute basis vectors in original column space
     basis_vectors = np.dot(UX.T, Vs).T
     # sort both in descending order of eigenvalues

--- a/nipy/modalities/fmri/fmristat/model.py
+++ b/nipy/modalities/fmri/fmristat/model.py
@@ -22,7 +22,7 @@ import copy
 import os.path as path
 
 import numpy as np
-import scipy.linalg as spl
+import numpy.linalg as npl
 
 from nipy.algorithms.statistics.models.regression import (
     OLSModel, ARModel, ar_bias_corrector, ar_bias_correct)
@@ -180,7 +180,7 @@ def estimateAR(resid, design, order=1):
     output : array
         shape (order, resid
     """
-    invM = ar_bias_corrector(design, spl.pinv(design), order)
+    invM = ar_bias_corrector(design, npl.pinv(design), order)
     return ar_bias_correct(resid, order, invM)
 
 


### PR DESCRIPTION
This is an alternative to #394.  In this PR, we switch from using
scipy.linalg.pinv to using numpy.linalg.pinv, on the basis that, at least as of
scipy 0.17, numpy pinv is more accurate, as measured by least squares sum of
squared errors.

This fixes the test failure we were getting from scipy 0.17 without the need to
relax the precision threshold (#394).

Of course, this PR might cause subtle changes in results.  On the other hand,
that will likely be true for scipy 0.17 compared to scipy 0.16 without this
change.