### PR TITLE
TST: relax test precision a little for 32-bit

### DIFF
--- a/nipy/algorithms/statistics/tests/test_intrinsic_volumes.py
+++ b/nipy/algorithms/statistics/tests/test_intrinsic_volumes.py
@@ -151,8 +151,11 @@ def test_mu1tri():
 
 
 def test_mu2tet():
-    assert_equal(intvol.mu2_tet(0,0,0,0,1,0,0,1,0,1), (3./2 + np.sqrt(3./4))/2)
-
+    # 15 digit precision error found on 32-bit Linux
+    # https://travis-ci.org/MacPython/nipy-wheels/jobs/140268248#L725
+    assert_almost_equal(intvol.mu2_tet(0,0,0,0,1,0,0,1,0,1),
+                        (3./2 + np.sqrt(3./4))/2,
+                        15)
 
 def pts2mu1_tet(d, a, b, c):
     """ Accept point coordinates for calling mu1_tet


### PR DESCRIPTION
32-bit giving test precision error::

    line 154, in test_mu2tet
    assert_equal(intvol.mu2_tet(0,0,0,0,1,0,0,1,0,1), (3./2 +
                np.sqrt(3./4))/2)
    AssertionError: 1.1830127018922194 != 1.1830127018922192

See: https://travis-ci.org/MacPython/nipy-wheels/jobs/140268243#L451