### PR TITLE
BF: allow for generic IOError-based exception to be thrown when loading non existing file

### DIFF
--- a/nipy/io/tests/test_image_io.py
+++ b/nipy/io/tests/test_image_io.py
@@ -41,7 +41,10 @@ def load_template_img():
 
 def test_badfile():
     filename = "bad_file.foo"
-    assert_raises(ImageFileError, load_image, filename)
+    # nibabel prior 2.1.0 was throwing ImageFileError and then more specific
+    # FileNotFileNotFoundError which should be a subclass of IOError.
+    # To not mess with version specific imports, checking for IOError
+    assert_raises((ImageFileError, IOError), load_image, filename)
 
 
 @if_templates


### PR DESCRIPTION
NB not sure how this one escaped my testing of dependents when checking one of nibabel rcs

need it now to resole FTBFS on debians https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=836538