### PR TITLE
MRG: refactor intvol to accept any input

### DIFF
--- a/nipy/algorithms/statistics/tests/test_utils.py
+++ b/nipy/algorithms/statistics/tests/test_utils.py
@@ -7,14 +7,18 @@ from scipy.stats import norm
 import scipy.linalg as spl
 
 
-from ..utils import multiple_mahalanobis, z_score, multiple_fast_inv
-from nose.tools import assert_true
-from numpy.testing import assert_almost_equal, assert_array_almost_equal
+from ..utils import (multiple_mahalanobis, z_score, multiple_fast_inv,
+                     check_cast_bin8)
+from nose.tools import assert_true, assert_equal, assert_raises
+from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
+                           assert_array_equal)
+
 
 def test_z_score():
     p = np.random.rand(10)
     z = z_score(p)
     assert_array_almost_equal(norm.sf(z), p)
+
 
 def test_mahalanobis():
     x = np.random.rand(100) / 100
@@ -22,6 +26,7 @@ def test_mahalanobis():
     A = np.dot(A.transpose(), A) + np.eye(100)
     mah = np.dot(x, np.dot(np.linalg.inv(A), x))
     assert_almost_equal(mah, multiple_mahalanobis(x, A), decimal=1)
+
 
 def test_mahalanobis2():
     x = np.random.randn(100, 3)
@@ -35,6 +40,7 @@ def test_mahalanobis2():
     f_mah = (multiple_mahalanobis(x, Aa))[i]
     assert_almost_equal(mah, f_mah)
 
+
 def test_multiple_fast_inv():
     shape = (10, 20, 20)
     X = np.random.randn(*shape)
@@ -46,6 +52,26 @@ def test_multiple_fast_inv():
     assert_array_almost_equal(X_inv_ref, X_inv)
 
 
-if __name__ == "__main__":
-    import nose
-    nose.run(argv=['', __file__])
+def assert_equal_bin8(actual, expected):
+    res = check_cast_bin8(actual)
+    assert_equal(res.shape, actual.shape)
+    assert_true(res.dtype.type == np.uint8)
+    assert_array_equal(res, expected)
+
+
+def test_check_cast_bin8():
+    # Function to return np.uint8 array with check whether array is binary.
+    for in_dtype in np.sctypes['int'] + np.sctypes['uint']:
+        assert_equal_bin8(np.array([0, 1, 1, 1], in_dtype), [0, 1, 1, 1])
+        assert_equal_bin8(np.array([[0, 1], [1, 1]], in_dtype),
+                          [[0, 1], [1, 1]])
+        assert_raises(ValueError, check_cast_bin8,
+                      np.array([0, 1, 2], dtype=in_dtype))
+    for in_dtype in np.sctypes['float']:
+        assert_equal_bin8(np.array([0, 1, 1, -0], np.float), [0, 1, 1, 0])
+        assert_equal_bin8(np.array([[0, 1], [1, -0]], np.float),
+                          [[0, 1], [1, 0]])
+        assert_raises(ValueError, check_cast_bin8,
+                      np.array([0, 0.1, 1], dtype=in_dtype))
+        assert_raises(ValueError, check_cast_bin8,
+                      np.array([0, -1, 1], dtype=in_dtype))

--- a/nipy/algorithms/statistics/utils.py
+++ b/nipy/algorithms/statistics/utils.py
@@ -240,6 +240,7 @@ def join_complexes(*complexes):
                 faces[i+1] = faces[i+1].union(c[i+1])
     return faces
 
+
 def decompose3d(shape, dim=4):
     """
     Return all (dim-1)-dimensional simplices in a triangulation
@@ -417,3 +418,25 @@ def test_EC2(shape):
 test_EC2.__test__ = False
 
 
+def check_cast_bin8(arr):
+    """ Return binary array `arr` as uint8 type, or raise if not binary.
+
+    Parameters
+    ----------
+    arr : array-like
+
+    Returns
+    -------
+    bin8_arr : uint8 array
+        `bin8_arr` has same shape as `arr`, is of dtype ``np.uint8``, with
+        values 0 and 1 only.
+
+    Raises
+    ------
+    ValueError
+        When the array is not binary.  Speficically, raise if, for any element
+        ``e``, ``e != (e != 0)``.
+    """
+    if np.any(arr != (arr !=0)):
+        raise ValueError('input array should only contain values 0 and 1')
+    return arr.astype(np.uint8)


### PR DESCRIPTION
Allow any input type to the intvol routines.

Some refactoring to specify variable types in Cython file.

@jonathan-taylor - hoping against hope for a review ...

[skip ci]