### PR TITLE
BF: do not check sympy implementation details (ie for `_imp_`) + nosetester doctest fix

### DIFF
--- a/nipy/fixes/numpy/testing/nosetester.py
+++ b/nipy/fixes/numpy/testing/nosetester.py
@@ -21,7 +21,8 @@ def get_package_name(filepath):
 
     Examples
     --------
-    >>> np.testing.nosetester.get_package_name('nonsense')
+    >>> from numpy.testing import nosetester
+    >>> nosetester.get_package_name('nonsense')
     'numpy'
 
     """

--- a/nipy/modalities/fmri/tests/test_aliases.py
+++ b/nipy/modalities/fmri/tests/test_aliases.py
@@ -42,9 +42,8 @@ def test_implemented_function():
     assert_equal(l2(3), np.sqrt(3))
     # check that we can pass in a sympy function as input
     func = sympy.Function('myfunc')
-    assert_false(hasattr(func, '_imp_'))
     f = implemented_function(func, lambda x: 2*x)
-    assert_true(hasattr(func, '_imp_'))
+    assert(f)
 
 
 def test_lambdify():


### PR DESCRIPTION
NB originally misfiled issue under nipype ;)  so here is full description

### Summary
Originally reported against debian package (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=906388) and reconfirmed locally that on debian sid/unstable there is a following failure:
```

======================================================================
FAIL: nipy.modalities.fmri.tests.test_aliases.test_implemented_function
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/build/nipy-0.4.2/debian/tmp/usr/lib/python2.7/dist-packages/nipy/modalities/fmri/tests/test_aliases.py", line 47, in test_implemented_function
    assert_true(hasattr(func, '_imp_'))
AssertionError: False is not true

----------------------------------------------------------------------
Ran 4522 tests in 174.498s

FAILED (SKIP=6, failures=1)
make[1]: *** [debian/rules:58: test] Error 1
make[1]: Leaving directory '/build/nipy-0.4.2'
make: *** [debian/rules:19: binary-arch] Error 2

> python -m nose -s -v --pdb /build/nipy-0.4.2/debian/tmp/usr/lib/python2.7/dist-packages/nipy/modalities/fmri/tests/test_aliases.py
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
nose.plugins.cover: INFO: Coverage report will include only packages: ['nipy']
nipy.modalities.fmri.tests.test_aliases.test_implemented_function ... > /usr/lib/python2.7/unittest/case.py(422)assertTrue()
-> raise self.failureException(msg)
(Pdb) up
> /build/nipy-0.4.2/debian/tmp/usr/lib/python2.7/dist-packages/nipy/modalities/fmri/tests/test_aliases.py(47)test_implemented_function()
-> assert_true(hasattr(func, '_imp_'))
(Pdb) p func
myfunc
(Pdb) p dir(func)
['__abs__', '__add__', '__class__', '__complex__', '__delattr__', '__dict__', '__div__', '__doc__', '__eq__', '__float__', '__floordiv__', '__format__', '__ge__', '__getattribute__', '__getnewargs__', '__getstate__', '__gt__', '__hash__', '__init__', '__int__', '__le__', '__long__', '__lt__', '__mod__', '__module__', '__mul__', '__ne__', '__neg__', '__new__', '__pos__', '__pow__', '__radd__', '__rdiv__', '__reduce__', '__reduce_ex__', '__repr__', '__rfloordiv__', '__rmod__', '__rmul__', '__rpow__', '__rsub__', '__rtruediv__', '__setattr__', '__setstate__', '__sizeof__', '__slots__', '__str__', '__sub__', '__subclasshook__', '__truediv__', '__trunc__', '__weakref__', '_accept_eval_derivative', '_args', '_assumptions', '_compare_pretty', '_constructor_postprocessor_mapping', '_diff_wrt', '_eval_adjoint', '_eval_as_leading_term', '_eval_aseries', '_eval_conjugate', '_eval_derivative', '_eval_derivative_n_times', '_eval_evalf', '_eval_expand_complex', '_eval_interval', '_eval_is_algebraic_expr', '_eval_is_commutative', '_eval_is_complex', '_eval_is_negative', '_eval_is_polynomial', '_eval_is_positive', '_eval_is_rational_function', '_eval_lseries', '_eval_nseries', '_eval_power', '_eval_rewrite', '_eval_subs', '_eval_transpose', '_evalf', '_exec_constructor_postprocessors', '_expand_hint', '_explicit_class_assumptions', '_extra_kwargs', '_from_mpmath', '_has', '_has_matcher', '_hashable_content', '_mhash', '_nargs', '_op_priority', '_parse_order', '_pow', '_prop_handler', '_random', '_recursive_call', '_sage_', '_should_evalf', '_sorted_args', '_subs', '_to_mpmath', '_visit_eval_derivative_array', '_visit_eval_derivative_scalar', '_xreplace', 'adjoint', 'apart', 'args', 'args_cnc', 'as_base_exp', 'as_coeff_Add', 'as_coeff_Mul', 'as_coeff_add', 'as_coeff_exponent', 'as_coeff_mul', 'as_coefficient', 'as_coefficients_dict', 'as_content_primitive', 'as_expr', 'as_independent', 'as_leading_term', 'as_numer_denom', 'as_ordered_factors', 'as_ordered_terms', 'as_poly', 'as_powers_dict', 'as_real_imag', 'as_terms', 'assumptions0', 'atoms', 'cancel', 'canonical_variables', 'class_key', 'coeff', 'collect', 'combsimp', 'compare', 'compute_leading_term', 'conjugate', 'copy', 'could_extract_minus_sign', 'count', 'count_ops', 'default_assumptions', 'diff', 'doit', 'dummy_eq', 'equals', 'eval', 'evalf', 'expand', 'expr_free_symbols', 'extract_additively', 'extract_branch_factor', 'extract_multiplicatively', 'factor', 'fdiff', 'find', 'fourier_series', 'fps', 'free_symbols', 'fromiter', 'func', 'gammasimp', 'getO', 'getn', 'has', 'integrate', 'invert', 'is_Add', 'is_AlgebraicNumber', 'is_Atom', 'is_Boolean', 'is_Derivative', 'is_Dummy', 'is_Equality', 'is_Float', 'is_Function', 'is_Indexed', 'is_Integer', 'is_MatAdd', 'is_MatMul', 'is_Matrix', 'is_Mul', 'is_Not', 'is_Number', 'is_NumberSymbol', 'is_Order', 'is_Piecewise', 'is_Point', 'is_Poly', 'is_Pow', 'is_Rational', 'is_Relational', 'is_Symbol', 'is_Vector', 'is_Wild', 'is_algebraic', 'is_algebraic_expr', 'is_antihermitian', 'is_commutative', 'is_comparable', 'is_complex', 'is_composite', 'is_constant', 'is_even', 'is_finite', 'is_hermitian', 'is_hypergeometric', 'is_imaginary', 'is_infinite', 'is_integer', 'is_irrational', 'is_negative', 'is_noninteger', 'is_nonnegative', 'is_nonpositive', 'is_nonzero', 'is_number', 'is_odd', 'is_polar', 'is_polynomial', 'is_positive', 'is_prime', 'is_rational', 'is_rational_function', 'is_real', 'is_symbol', 'is_transcendental', 'is_zero', 'leadterm', 'limit', 'lseries', 'match', 'matches', 'n', 'normal', 'nseries', 'nsimplify', 'powsimp', 'primitive', 'radsimp', 'ratsimp', 'rcall', 'refine', 'removeO', 'replace', 'rewrite', 'round', 'separate', 'series', 'simplify', 'sort_key', 'subs', 'taylor_term', 'together', 'transpose', 'trigsimp', 'xreplace']
```

originally happened with sympy 1.2 and now with 1.3 (had to update to avoid other sympy bugs).

I do not see anywhere in the code use/reliance on having `_imp_` besides using it in the test:

```python
    # check that we can pass in a sympy function as input
    func = sympy.Function('myfunc')
    assert_false(hasattr(func, '_imp_'))
    f = implemented_function(func, lambda x: 2*x)
    assert_true(hasattr(func, '_imp_'))
```
and by looking at `dir(func)` with current sympy before/after implemented_function there is no difference.  Is it really needed for this test??  seems to be not - no need to test internal implementation of sympy here AFAIK. 