### PR TITLE
Remove deprecated references

### DIFF
--- a/nipy/algorithms/statistics/rft.py
+++ b/nipy/algorithms/statistics/rft.py
@@ -20,8 +20,7 @@ import numpy as np
 from numpy.linalg import pinv
 
 from scipy import stats
-from scipy.misc import factorial
-from scipy.special import gamma, gammaln, beta, hermitenorm
+from scipy.special import factorial, gamma, gammaln, beta, hermitenorm
 
 # Legacy repr printing from numpy.
 from nipy.testing import legacy_printing as setup_module  # noqa

--- a/nipy/algorithms/statistics/tests/test_rft.py
+++ b/nipy/algorithms/statistics/tests/test_rft.py
@@ -4,9 +4,8 @@ from __future__ import absolute_import
 
 import numpy as np
 
-from scipy.special import gammaln, hermitenorm
+from scipy.special import factorial, gammaln, hermitenorm
 import scipy.stats
-from scipy.misc import factorial
 
 from .. import rft
 


### PR DESCRIPTION
As of Scipy 1.0.0 the factorial method no longer resides in scipy.misc, but it is found in scipy.special instead. I have fixed the imports in the files that I could find that try to import factorial from scipy.misc.