### PR TITLE
Fixed deprecated scipy 1.3.0 imports 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       env:
         # Definitive source for these in nipy/info.py
         - PRE_DEPENDS="numpy==1.6.0"
-        - DEPENDS="scipy==0.9.0 sympy==0.7.0 nibabel==1.2.0"
+        - DEPENDS="scipy==0.14.0 sympy==0.7.0 nibabel==1.2.0"
     # Test compiling against external lapack
     - python: 3.4
       env:

--- a/nipy/algorithms/statistics/rft.py
+++ b/nipy/algorithms/statistics/rft.py
@@ -20,8 +20,7 @@ import numpy as np
 from numpy.linalg import pinv
 
 from scipy import stats
-from scipy.misc import factorial
-from scipy.special import gamma, gammaln, beta, hermitenorm
+from scipy.special import factorial, gamma, gammaln, beta, hermitenorm
 
 # Legacy repr printing from numpy.
 from nipy.testing import legacy_printing as setup_module  # noqa

--- a/nipy/algorithms/statistics/tests/test_rft.py
+++ b/nipy/algorithms/statistics/tests/test_rft.py
@@ -4,9 +4,8 @@ from __future__ import absolute_import
 
 import numpy as np
 
-from scipy.special import gammaln, hermitenorm
+from scipy.special import factorial, gammaln, hermitenorm
 import scipy.stats
-from scipy.misc import factorial
 
 from .. import rft
 

--- a/nipy/info.py
+++ b/nipy/info.py
@@ -147,7 +147,7 @@ the nipy distribution.
 # Update in .travis.yml
 # Update in requirements.txt
 NUMPY_MIN_VERSION='1.6.0'
-SCIPY_MIN_VERSION = '0.9.0'
+SCIPY_MIN_VERSION = '0.14.0'
 NIBABEL_MIN_VERSION = '1.2'
 SYMPY_MIN_VERSION = '0.7.0'
 MAYAVI_MIN_VERSION = '3.0'

--- a/nipy/labs/group/permutation_test.py
+++ b/nipy/labs/group/permutation_test.py
@@ -6,7 +6,7 @@ from __future__ import print_function, absolute_import
 
 # Third-party imports
 import numpy as np
-import scipy.misc as sm
+import scipy.special as sp
 import warnings
 
 # Our own imports
@@ -374,7 +374,7 @@ class permutation_test(object):
         elif self.nsamples == 2:
             n1,p = self.data1.shape[self.axis], self.data1.shape[1-self.axis]
             n2 = self.data2.shape[self.axis]
-            max_nperms = sm.comb(n1+n2,n1,exact=1)
+            max_nperms = sp.comb(n1+n2,n1,exact=1)
             data = np.concatenate((self.data1,self.data2), self.axis)
             if self.vardata1 is not None:
                 vardata = np.concatenate((self.vardata1,self.vardata2), self.axis)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # See nipy/info.py for requirement definitions
 numpy>=1.6.0
-scipy>=0.9.0
+scipy>=0.14.0
 sympy>=0.7.0
 nibabel>=1.2.0


### PR DESCRIPTION
New deprecation of 1.3.0. caused some nipy imports to fail. More specifically: 
- `scipy.misc.factorial`
- `scipy.misc.comb`

This PR replaces the deprecated imports by the new ones (using `scipy.special`).

Fixes #453 