### PR TITLE
Fix get_3d_peaks when using mask

### DIFF
--- a/nipy/labs/statistical_mapping.py
+++ b/nipy/labs/statistical_mapping.py
@@ -185,7 +185,7 @@ def get_3d_peaks(image, mask=None, threshold=0., nn=18, order_th=0):
     if mask is not None:
         bmask = mask.get_data().ravel()
         data = image.get_data().ravel()[bmask > 0]
-        xyz = np.array(np.where(bmask > 0)).T
+        xyz = np.array(np.where(mask.get_data() > 0)).T
     else:
         shape = image.shape
         data = image.get_data().ravel()


### PR DESCRIPTION
## Issue 
The `get_3d_peaks` function from `nipy.labs.statistical_mapping` throws an error when using it with a mask.
### Minimal reproductible example
```python
from nilearn import datasets, masking, image
from nipy.labs.statistical_mapping import get_3d_peaks

template = datasets.load_mni152_template()
mask = masking.compute_gray_matter_mask(template)

imgs = datasets.fetch_neurovault_motor_task()
img = image.resample_to_img(imgs.images[0], template)

get_3d_peaks(img, mask=mask)
```

### Error
```
Traceback (most recent call last):
  File "minimal.py", line 10, in <module>
    get_3d_peaks(img, mask=mask)
  File ".../venv/lib/python3.7/site-packages/nipy/labs/statistical_mapping.py", line 199, in get_3d_peaks
    ff = field_from_graph_and_data(wgraph_from_3d_grid(xyz, k=18), data)
  File ".../venv/lib/python3.7/site-packages/nipy/algorithms/graph/graph.py", line 527, in wgraph_from_3d_grid
    raise ValueError('xyz should have shape n * 3')
ValueError: xyz should have shape n * 3
```

### Versions
```
nipy==0.4.2
nilearn==0.5.2
```

## Fix
`xyz` must be of shape n*3 to be used by `wgraph_from_3d_grid`, hence the use of the 3D mask array instead of the 1D ravelled mask array in `np.where`.