### PR TITLE
kludgy fixes for numpy 1.18.1 and python 3.8 compatibility

### DIFF
--- a/nipy/testing/decorators.py
+++ b/nipy/testing/decorators.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """ Extend numpy's decorators to use nipy's gui and data labels.
 
 This module should not import nose at the top level to avoid a run-time
@@ -8,7 +6,7 @@ dependency on nose.
 from __future__ import print_function
 from __future__ import absolute_import
 
-from numpy.testing.decorators import *
+from numpy.testing._private.decorators import *
 
 from nipy.utils import templates, example_data, DataError
 


### PR DESCRIPTION
This PR addresses two issues:

1.  import of numpy.testing.decorators was failing in numpy 1.18.1 (as in issue #456 )
- as a stopgap fix, changed this to import the now private decorators.  not good practice obviously, but then again, neither is using an outdated version of numpy just to avoid an error

2. in Python 3.8, the emacs/vi mode lines at the top of decorators.py appeared to be driving a syntax error: SyntaxError: from __future__ imports must occur at the beginning of the file.
- removing the mode lines eliminated this error.

neither of these is an awesome fix.  but together they allow nipy to work with the latest python and numpy releases