### PR TITLE
shebang to python3 not python

### DIFF
--- a/doc/devel/tools/tricked_out_emacs.rst
+++ b/doc/devel/tools/tricked_out_emacs.rst
@@ -83,7 +83,7 @@ Install pylint_.  Debian packages pylint_ as ``pylint``. Put the
 `flymake .emacs snippet`_ in your ``.emacs`` file.  You will see, in the
 emacs_python_mode_ page, that you will need to save this::
 
-    #!/usr/bin/env python
+    #!/usr/bin/env python3
     
     import re
     import sys

--- a/doc/sphinxext/autosummary_generate.py
+++ b/doc/sphinxext/autosummary_generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 r"""

--- a/examples/affine_registration.py
+++ b/examples/affine_registration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """

--- a/examples/algorithms/bayesian_gaussian_mixtures.py
+++ b/examples/algorithms/bayesian_gaussian_mixtures.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/algorithms/clustering_comparisons.py
+++ b/examples/algorithms/clustering_comparisons.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/algorithms/gaussian_mixture_models.py
+++ b/examples/algorithms/gaussian_mixture_models.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/algorithms/mixed_effects.py
+++ b/examples/algorithms/mixed_effects.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/algorithms/ward_clustering.py
+++ b/examples/algorithms/ward_clustering.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function, division # Python 2/3 compatibility

--- a/examples/compute_fmri_contrast.py
+++ b/examples/compute_fmri_contrast.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/core/parcel_generator.py
+++ b/examples/core/parcel_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/create_tempimage.py
+++ b/examples/create_tempimage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """This example shows how to create a temporary image to use during processing.

--- a/examples/ds105/view_contrasts_3d.py
+++ b/examples/ds105/view_contrasts_3d.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """A quick and dirty example of using Mayavi to overlay anatomy and activation.

--- a/examples/fiac/view_contrasts_3d.py
+++ b/examples/fiac/view_contrasts_3d.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """A quick and dirty example of using Mayavi to overlay anatomy and activation.

--- a/examples/formula/fir.py
+++ b/examples/formula/fir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """ Example of FIR model using formula framework

--- a/examples/formula/multi_session_contrast.py
+++ b/examples/formula/multi_session_contrast.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """ Example of more than one run in the same model

--- a/examples/formula/parametric_design.py
+++ b/examples/formula/parametric_design.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """

--- a/examples/formula/simple_contrast.py
+++ b/examples/formula/simple_contrast.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """ A simple contrast for an FMRI HRF model """

--- a/examples/image_from_array.py
+++ b/examples/image_from_array.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Create a nifti image from a numpy array and an affine transform.

--- a/examples/interfaces/process_ds105.py
+++ b/examples/interfaces/process_ds105.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 ''' Single subject analysis script for SPM / Open FMRI ds105

--- a/examples/interfaces/process_fiac.py
+++ b/examples/interfaces/process_fiac.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 ''' Single subject analysis script for SPM / FIAC '''

--- a/examples/labs/bayesian_structural_analysis.py
+++ b/examples/labs/bayesian_structural_analysis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/blob_extraction.py
+++ b/examples/labs/blob_extraction.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/demo_dmtx.py
+++ b/examples/labs/demo_dmtx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/example_glm.py
+++ b/examples/labs/example_glm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/glm_lowlevel.py
+++ b/examples/labs/glm_lowlevel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/group_reproducibility_analysis.py
+++ b/examples/labs/group_reproducibility_analysis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/hierarchical_rois.py
+++ b/examples/labs/hierarchical_rois.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/histogram_fits.py
+++ b/examples/labs/histogram_fits.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/multi_subject_parcellation.py
+++ b/examples/labs/multi_subject_parcellation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/bayesian_structural_analysis.py
+++ b/examples/labs/need_data/bayesian_structural_analysis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/demo_blob_from_image.py
+++ b/examples/labs/need_data/demo_blob_from_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/demo_roi.py
+++ b/examples/labs/need_data/demo_roi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/demo_ward_clustering.py
+++ b/examples/labs/need_data/demo_ward_clustering.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/example_roi_and_glm.py
+++ b/examples/labs/need_data/example_roi_and_glm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/first_level_fiac.py
+++ b/examples/labs/need_data/first_level_fiac.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/get_data_light.py
+++ b/examples/labs/need_data/get_data_light.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/glm_beta_and_variance.py
+++ b/examples/labs/need_data/glm_beta_and_variance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function

--- a/examples/labs/need_data/group_reproducibility_analysis.py
+++ b/examples/labs/need_data/group_reproducibility_analysis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/histogram_fits.py
+++ b/examples/labs/need_data/histogram_fits.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/localizer_glm_ar.py
+++ b/examples/labs/need_data/localizer_glm_ar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/one_sample_t_test.py
+++ b/examples/labs/need_data/one_sample_t_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function

--- a/examples/labs/need_data/parcel_intra.py
+++ b/examples/labs/need_data/parcel_intra.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/parcel_multisubj.py
+++ b/examples/labs/need_data/parcel_multisubj.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/permutation_test.py
+++ b/examples/labs/need_data/permutation_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/plot_registration.py
+++ b/examples/labs/need_data/plot_registration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/tmin_statistic.py
+++ b/examples/labs/need_data/tmin_statistic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function

--- a/examples/labs/need_data/viz.py
+++ b/examples/labs/need_data/viz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/need_data/viz3d.py
+++ b/examples/labs/need_data/viz3d.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function

--- a/examples/labs/onesample_group.py
+++ b/examples/labs/onesample_group.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """

--- a/examples/labs/permutation_test_fakedata.py
+++ b/examples/labs/permutation_test_fakedata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """ Example script for group permutation testing """

--- a/examples/labs/two_sample_mixed_effects.py
+++ b/examples/labs/two_sample_mixed_effects.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/watershed_labeling.py
+++ b/examples/labs/watershed_labeling.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/labs/write_paradigm_file.py
+++ b/examples/labs/write_paradigm_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function # Python 2/3 compatibility

--- a/examples/parcel_group_analysis.py
+++ b/examples/parcel_group_analysis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Example running a parcel-based second-level analysis from a set of

--- a/examples/space_time_realign.py
+++ b/examples/space_time_realign.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """

--- a/examples/tissue_classification.py
+++ b/examples/tissue_classification.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """ Script example of tissue classification

--- a/lib/lapack_lite/remake/make_lite.py
+++ b/lib/lapack_lite/remake/make_lite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os
 import fortran

--- a/nipy/algorithms/clustering/setup.py
+++ b/nipy/algorithms/clustering/setup.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, print_function
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 def configuration(parent_package='',top_path=None):
 

--- a/nipy/algorithms/clustering/tests/test_clustering.py
+++ b/nipy/algorithms/clustering/tests/test_clustering.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # to run only the simple tests:
 # python testClustering.py Test_Clustering

--- a/nipy/algorithms/clustering/tests/test_ggm.py
+++ b/nipy/algorithms/clustering/tests/test_ggm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from __future__ import absolute_import
 

--- a/nipy/algorithms/clustering/tests/test_gmm.py
+++ b/nipy/algorithms/clustering/tests/test_gmm.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # to run only the simple tests:
 # python testClustering.py Test_Clustering

--- a/nipy/algorithms/graph/setup.py
+++ b/nipy/algorithms/graph/setup.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import numpy
 
 

--- a/nipy/algorithms/graph/tests/test_bipartite_graph.py
+++ b/nipy/algorithms/graph/tests/test_bipartite_graph.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import numpy as np
 import numpy.random as nr

--- a/nipy/algorithms/graph/tests/test_field.py
+++ b/nipy/algorithms/graph/tests/test_field.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import numpy as np
 import numpy.random as nr
 

--- a/nipy/algorithms/graph/tests/test_graph.py
+++ b/nipy/algorithms/graph/tests/test_graph.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import numpy as np
 import numpy.random as nr

--- a/nipy/algorithms/registration/scripting.py
+++ b/nipy/algorithms/registration/scripting.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 

--- a/nipy/algorithms/registration/tests/test_affine.py
+++ b/nipy/algorithms/registration/tests/test_affine.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import numpy as np
 

--- a/nipy/algorithms/registration/tests/test_histogram_registration.py
+++ b/nipy/algorithms/registration/tests/test_histogram_registration.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import numpy as np
 

--- a/nipy/algorithms/registration/tests/test_scripting.py
+++ b/nipy/algorithms/registration/tests/test_scripting.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import absolute_import

--- a/nipy/algorithms/statistics/tests/test_quantile.py
+++ b/nipy/algorithms/statistics/tests/test_quantile.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import numpy as np
 from numpy import median as np_median

--- a/nipy/algorithms/statistics/tests/test_utils.py
+++ b/nipy/algorithms/statistics/tests/test_utils.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import numpy as np
 

--- a/nipy/labs/bindings/tests/test_array.py
+++ b/nipy/labs/bindings/tests/test_array.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Test fff_array wrapping 

--- a/nipy/labs/bindings/tests/test_blas1.py
+++ b/nipy/labs/bindings/tests/test_blas1.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Test BLAS 1

--- a/nipy/labs/bindings/tests/test_blas3.py
+++ b/nipy/labs/bindings/tests/test_blas3.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 #

--- a/nipy/labs/bindings/tests/test_linalg.py
+++ b/nipy/labs/bindings/tests/test_linalg.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Test fff linear algebra routines 

--- a/nipy/labs/glm/setup.py
+++ b/nipy/labs/glm/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import absolute_import, print_function
 
 

--- a/nipy/labs/glm/tests/test_glm.py
+++ b/nipy/labs/glm/tests/test_glm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import absolute_import
 
 import numpy as np

--- a/nipy/labs/utils/setup.py
+++ b/nipy/labs/utils/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import absolute_import, print_function
 
 

--- a/nipy/labs/utils/tests/test_misc.py
+++ b/nipy/labs/utils/tests/test_misc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import absolute_import
 
 import numpy as np

--- a/nipy/labs/viz_tools/activation_maps.py
+++ b/nipy/labs/viz_tools/activation_maps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Functions to do automatic visualization of activation-like maps.

--- a/scripts/nipy_3dto4d
+++ b/scripts/nipy_3dto4d
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 DESCRIP = 'Read 3D image files and write a 4D file'

--- a/scripts/nipy_4d_realign
+++ b/scripts/nipy_4d_realign
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 

--- a/scripts/nipy_4dto3d
+++ b/scripts/nipy_4dto3d
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 DESCRIP = 'Read 4D image file and write 3D nifti file for each volume'

--- a/scripts/nipy_diagnose
+++ b/scripts/nipy_diagnose
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 DESCRIP = 'Calculate and write results for diagnostic screen'

--- a/scripts/nipy_tsdiffana
+++ b/scripts/nipy_tsdiffana
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 DESCRIP = ' Analyze, plot time series difference metrics'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 import os

--- a/setup_egg.py
+++ b/setup_egg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Wrapper to run setup.py using setuptools."""

--- a/tools/build_dmgs.py
+++ b/tools/build_dmgs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Script to build dmgs for buildbot builds
 
 Example

--- a/tools/build_modref_templates.py
+++ b/tools/build_modref_templates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Script to auto-generate our API docs.

--- a/tools/doctest_extmods.py
+++ b/tools/doctest_extmods.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Run doctests in extension modules of <pkg_name>
 
 Collect extension modules in <pkg_name>

--- a/tools/fix_longtable.py
+++ b/tools/fix_longtable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ Fix sphinx latex output for longtable
 """
 import re

--- a/tools/gitwash_dumper.py
+++ b/tools/gitwash_dumper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ''' Checkout gitwash repo into directory and do search replace on name '''
 
 from __future__ import (absolute_import, division, print_function)

--- a/tools/nicythize
+++ b/tools/nicythize
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ nicythize
 
 Cythonize pyx files into C files as needed.

--- a/tools/nipnost
+++ b/tools/nipnost
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # vim: ft=python
 """ Run nosetests using nipy doctest plugin
 

--- a/tools/perlpie
+++ b/tools/perlpie
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Utility script for performing global search and replace with `perl -p ie`
 """

--- a/tools/refresh_readme.py
+++ b/tools/refresh_readme.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ Refresh README.rst file from long description
 
 Should be run from project root (containing setup.py)

--- a/tools/run_log_examples.py
+++ b/tools/run_log_examples.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import print_function, with_statement

--- a/tools/sneeze.py
+++ b/tools/sneeze.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Script to run nose with coverage reporting without boilerplate params.

--- a/tools/touch_cython_cs.py
+++ b/tools/touch_cython_cs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ Refresh modification times on Cython generated C files
 
 This is sometimes necessary on windows when the git checkout appears to

--- a/tools/trac2rst.py
+++ b/tools/trac2rst.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 ''' Script to do very basic conversion of TRAC to reST format '''


### PR DESCRIPTION
As on some platforms python might still be pointing to good old
python2 and I would expect python3 present - use it in shebang
to signify need for python3