### PR TITLE
MAINT: update minimum requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ matrix:
     - python: 2.7
       env:
         # Definitive source for these in nipy/info.py
-        - PRE_DEPENDS="numpy==1.6.0"
-        - DEPENDS="scipy==0.9.0 sympy==0.7.0 nibabel==1.2.0"
+        - PRE_DEPENDS="numpy==1.13"
+        - DEPENDS="scipy==1.0.0 sympy==1.0.0 nibabel==2.0.0"
     # Test compiling against external lapack
     - python: 3.6
       env:

--- a/nipy/info.py
+++ b/nipy/info.py
@@ -146,10 +146,10 @@ the nipy distribution.
 # Update in readme text above
 # Update in .travis.yml
 # Update in requirements.txt
-NUMPY_MIN_VERSION='1.6.0'
-SCIPY_MIN_VERSION = '0.9.0'
-NIBABEL_MIN_VERSION = '1.2'
-SYMPY_MIN_VERSION = '0.7.0'
+NUMPY_MIN_VERSION='1.13'
+SCIPY_MIN_VERSION = '1.0.0'
+NIBABEL_MIN_VERSION = '2.0'
+SYMPY_MIN_VERSION = '1.0'
 MAYAVI_MIN_VERSION = '3.0'
 CYTHON_MIN_VERSION = '0.12.1'
 


### PR DESCRIPTION
Minima as of about October 2017.

Attempt to fix some new failures using Piecewise, which boil down to:

```python
import sympy
t = sympy.symbols('t')
f1 = sympy.Piecewise((0, t <= 0), (1, t < 1), (0, True))
ff = sympy.lambdify('t', f1, "numpy")(0)
```

This gives an error where "iff" is not defined, for Sympy 0.7.0.