### PR TITLE
MRG: remove deprecated use of np.object

### DIFF
--- a/examples/interfaces/process_ds105.py
+++ b/examples/interfaces/process_ds105.py
@@ -204,7 +204,7 @@ class SPMSubjectAnalysis(object):
         return in_prefix
 
     def seg_norm(self, in_prefix=''):
-        def_tpms = np.zeros((3,1), dtype=np.object)
+        def_tpms = np.zeros((3,1), dtype=object)
         spm_path = spm_info.spm_path
         def_tpms[0] = pjoin(spm_path, 'tpm', 'grey.nii'),
         def_tpms[1] = pjoin(spm_path, 'tpm', 'white.nii'),

--- a/examples/interfaces/process_fiac.py
+++ b/examples/interfaces/process_fiac.py
@@ -99,7 +99,7 @@ def coregister(data_def):
 
 
 def segnorm(data_def):
-    def_tpms = np.zeros((3,1), dtype=np.object)
+    def_tpms = np.zeros((3,1), dtype=object)
     spm_path = spm_info.spm_path
     def_tpms[0] = pjoin(spm_path, 'tpm', 'grey.nii'),
     def_tpms[1] = pjoin(spm_path, 'tpm', 'white.nii'),

--- a/nipy/algorithms/utils/pca.py
+++ b/nipy/algorithms/utils/pca.py
@@ -29,7 +29,7 @@ def pca(data, axis=0, mask=None, ncomp=None, standardize=True,
 
     Parameters
     ----------
-    data : ndarray-like (np.float)
+    data : ndarray-like (float)
        The array on which to perform PCA over axis `axis` (below)
     axis : int, optional
        The axis over which to perform PCA (axis identifying
@@ -230,7 +230,7 @@ def _get_covariance(data, UX, rmse_scales_func, mask):
 
 def _get_basis_projections(data, subVX, rmse_scales_func):
     ncomp = subVX.shape[0]
-    out = np.empty((ncomp,) + data.shape[1:], np.float)
+    out = np.empty((ncomp,) + data.shape[1:], float)
     for i in range(data.shape[1]):
         Y = data[:,i].reshape((data.shape[0], -1))
         U = np.dot(subVX, Y)

--- a/nipy/algorithms/utils/tests/test_pca.py
+++ b/nipy/algorithms/utils/tests/test_pca.py
@@ -58,7 +58,7 @@ def res2pos1(res):
     new_axes = [None] * bps.ndim
     n_comps = res['basis_projections'].shape[axis]
     new_axes[axis] = slice(0,n_comps)
-    res['basis_projections'] = bps * signs[new_axes]
+    res['basis_projections'] = bps * signs[tuple(new_axes)]
     return res
 
 

--- a/nipy/core/reference/coordinate_map.py
+++ b/nipy/core/reference/coordinate_map.py
@@ -649,7 +649,8 @@ class AffineTransform(object):
             sym_inv = Matrix(self.affine).inv()
             m_inv = matrix2numpy(sym_inv).astype(aff_dt)
         else: # linalg inverse succeeded
-            if preserve_dtype and aff_dt != np.object_: # can we cast back?
+            # Do we need a specific dtype?  Can we cast to this dtype?
+            if preserve_dtype and aff_dt != np.object_:
                 m_inv_orig = m_inv
                 m_inv = m_inv.astype(aff_dt)
                 if not np.allclose(m_inv_orig, m_inv):

--- a/nipy/core/reference/coordinate_map.py
+++ b/nipy/core/reference/coordinate_map.py
@@ -649,7 +649,7 @@ class AffineTransform(object):
             sym_inv = Matrix(self.affine).inv()
             m_inv = matrix2numpy(sym_inv).astype(aff_dt)
         else: # linalg inverse succeeded
-            if preserve_dtype and aff_dt != np.object: # can we cast back?
+            if preserve_dtype and aff_dt != np.object_: # can we cast back?
                 m_inv_orig = m_inv
                 m_inv = m_inv.astype(aff_dt)
                 if not np.allclose(m_inv_orig, m_inv):

--- a/nipy/core/reference/coordinate_system.py
+++ b/nipy/core/reference/coordinate_system.py
@@ -117,7 +117,7 @@ class CoordinateSystem(object):
             raise ValueError('coord_names must have distinct names')
         # verify that the dtype is coord_dtype for sanity
         sctypes = (np.sctypes['int'] + np.sctypes['float'] +
-                   np.sctypes['complex'] + np.sctypes['uint'] + [np.object])
+                   np.sctypes['complex'] + np.sctypes['uint'] + [object])
         coord_dtype = np.dtype(coord_dtype)
         if coord_dtype not in sctypes:
             raise ValueError('Coordinate dtype should be one of %s' % sctypes)

--- a/nipy/core/reference/tests/test_coordinate_map.py
+++ b/nipy/core/reference/tests/test_coordinate_map.py
@@ -30,7 +30,7 @@ from nipy.testing import legacy_printing
 # Dtypes for testing coordinate map creation / processing
 _SYMPY_SAFE_DTYPES = (np.sctypes['int'] + np.sctypes['uint'] +
                       np.sctypes['float'] + np.sctypes['complex'] +
-                      [np.object])
+                      [object])
 # Sympy <= 1.1 does not handle numpy longcomplex correctly. See:
 # https://github.com/sympy/sympy/pull/12901
 if np.longcomplex in _SYMPY_SAFE_DTYPES:  # Not present for Windows

--- a/nipy/core/reference/tests/test_coordinate_system.py
+++ b/nipy/core/reference/tests/test_coordinate_system.py
@@ -56,7 +56,7 @@ def test_unique_coord_names():
 def test_dtypes():
     # invalid dtypes
     dtypes = np.sctypes['others']
-    dtypes.remove(np.object)
+    dtypes.remove(object)
     for dt in dtypes:
         assert_raises(ValueError, CoordinateSystem, 'ijk', 'test', dt)
     # compound dtype
@@ -64,7 +64,7 @@ def test_dtypes():
     assert_raises(ValueError, CoordinateSystem, 'ijk', 'test', dtype)
     # valid dtypes
     dtypes = (np.sctypes['int'] + np.sctypes['float'] + np.sctypes['complex'] +
-              [np.object])
+              [object])
     for dt in dtypes:
         cs = CoordinateSystem('ij', coord_dtype=dt)
         assert_equal(cs.coord_dtype, dt)


### PR DESCRIPTION
Apparently "object" is identical in behavior.