### PR TITLE
MRG: fix new interpolation errors with Scipy 1.6

### DIFF
--- a/nipy/algorithms/interpolation.py
+++ b/nipy/algorithms/interpolation.py
@@ -49,7 +49,7 @@ class ImageInterpolator(object):
         if self.order > 1:
             data = ndimage.spline_filter(
                 np.nan_to_num(self.image.get_data()),
-                self.order)
+                order=self.order, mode=self.mode)
         else:
             data = np.nan_to_num(self.image.get_data())
         if self._datafile is None:

--- a/nipy/algorithms/kernel_smooth.py
+++ b/nipy/algorithms/kernel_smooth.py
@@ -97,7 +97,7 @@ class LinearFilter(object):
         # roll coordinate axis to front
         _X = np.rollaxis(_X, axis)
         # convert coordinates to FWHM units
-        if self.fwhm is not 1.0:
+        if self.fwhm != 1.0:
             f = fwhm2sigma(self.fwhm)
             if f.shape == ():
                 f = np.ones(len(self.bshape)) * f

--- a/nipy/algorithms/tests/test_interpolator.py
+++ b/nipy/algorithms/tests/test_interpolator.py
@@ -14,14 +14,41 @@ from nose.tools import (assert_true, assert_false, assert_raises,
                         assert_equal, assert_not_equal)
 
 
+def test_interp_obj():
+    arr = np.arange(24).reshape((2, 3, 4))
+    coordmap =  vox2mni(np.eye(4))
+    img = Image(arr, coordmap)
+    interp = ImageInterpolator(img)
+    assert_equal(interp.mode, 'constant')
+    assert_equal(interp.order, 3)
+    # order is read-only
+    assert_raises(AttributeError,
+                  setattr,
+                  interp,
+                  'order',
+                  1)
+    interp = ImageInterpolator(img, mode='nearest')
+    assert_equal(interp.mode, 'nearest')
+    # mode is read-only
+    assert_raises(AttributeError,
+                  setattr,
+                  interp,
+                  'mode',
+                  'reflect')
+
+
 def test_interpolator():
     arr = np.arange(24).reshape((2, 3, 4))
     coordmap =  vox2mni(np.eye(4))
     img = Image(arr, coordmap)
-    # Interpolate off top right corner with different modes
-    interp = ImageInterpolator(img, mode='nearest')
-    assert_almost_equal(interp.evaluate([0, 0, 4]), arr[0, 0, -1])
-    interp = ImageInterpolator(img, mode='constant', cval=0)
-    assert_array_equal(interp.evaluate([0, 0, 4]), 0)
-    interp = ImageInterpolator(img, mode='constant', cval=1)
-    assert_array_equal(interp.evaluate([0, 0, 4]), 1)
+    isx = np.indices(arr.shape)
+    for order in range(5):
+        interp = ImageInterpolator(img, mode='nearest', order=order)
+        # Interpolate at existing points.
+        assert_almost_equal(interp.evaluate(isx), arr)
+        # Interpolate off top right corner with different modes
+        assert_almost_equal(interp.evaluate([0, 0, 4]), arr[0, 0, -1])
+        interp = ImageInterpolator(img, mode='constant', order=order, cval=0)
+        assert_array_equal(interp.evaluate([0, 0, 4]), 0)
+        interp = ImageInterpolator(img, mode='constant', order=order, cval=1)
+        assert_array_equal(interp.evaluate([0, 0, 4]), 1)


### PR DESCRIPTION
Scipy >= 1.6.0 not longer guarantees that you get the same result when
interpolating directly (with map_coordinates, prefilter=True - the default) and
when using pre-calculated filters (map_coordinates, prefilter=False).

Therefore, we have to pad the calculated filter to get the same result.

See:

* https://github.com/nipy/nipy/issues/468
* https://github.com/scipy/scipy/issues/13600