### PR TITLE
MRG: Extend testing, fix / simplify interpolation

### DIFF
--- a/nipy/algorithms/tests/test_interpolator.py
+++ b/nipy/algorithms/tests/test_interpolator.py
@@ -1,7 +1,11 @@
 """ Testing interpolation module
 """
 
+from itertools import product
+
 import numpy as np
+
+from scipy.ndimage import map_coordinates
 
 from nipy.core.api import Image, vox2mni
 
@@ -38,17 +42,48 @@ def test_interp_obj():
 
 
 def test_interpolator():
-    arr = np.arange(24).reshape((2, 3, 4))
+    shape = (2, 3, 4)
+    arr = np.arange(24).reshape(shape)
     coordmap =  vox2mni(np.eye(4))
     img = Image(arr, coordmap)
-    isx = np.indices(arr.shape)
+    ixs = np.indices(arr.shape).astype(float)
     for order in range(5):
         interp = ImageInterpolator(img, mode='nearest', order=order)
         # Interpolate at existing points.
-        assert_almost_equal(interp.evaluate(isx), arr)
+        assert_almost_equal(interp.evaluate(ixs), arr)
+        # Interpolate at half voxel shift
+        ixs_x_shift = ixs.copy()
+        # Interpolate inside and outside at knots
+        ixs_x_shift[0] += 1
+        res = interp.evaluate(ixs_x_shift)
+        assert_almost_equal(res, np.tile(arr[1], (2, 1, 1)))
+        ixs_x_shift[0] -= 2
+        res = interp.evaluate(ixs_x_shift)
+        assert_almost_equal(res, np.tile(arr[0], (2, 1, 1)))
+        # Interpolate at mid-points inside and outside
+        ixs_x_shift[0] += 0.5
+        res = interp.evaluate(ixs_x_shift)
+        # Check inside.
+        mid_arr = np.mean(arr, axis=0) if order > 0 else arr[1]
+        assert_almost_equal(res[1], mid_arr)
         # Interpolate off top right corner with different modes
         assert_almost_equal(interp.evaluate([0, 0, 4]), arr[0, 0, -1])
         interp = ImageInterpolator(img, mode='constant', order=order, cval=0)
         assert_array_equal(interp.evaluate([0, 0, 4]), 0)
         interp = ImageInterpolator(img, mode='constant', order=order, cval=1)
         assert_array_equal(interp.evaluate([0, 0, 4]), 1)
+        # Check against direct ndimage interpolation
+        # Need floating point input array to replicate
+        # our floating point backing store.
+        farr = arr.astype(float)
+        for offset, axis, mode in product(np.linspace(-2, 2, 15),
+                                          range(3),
+                                          ('nearest', 'constant')):
+            interp = ImageInterpolator(img, mode=mode, order=order)
+            coords = ixs.copy()
+            slicer = tuple(None if i == axis else 0 for i in range(3))
+            coords[slicer] = coords[slicer] + offset
+            actual = interp.evaluate(coords)
+            expected = map_coordinates(farr, coords, mode=mode, order=order)
+            assert_almost_equal(actual, expected)
+            del interp


### PR DESCRIPTION
Extend testing of prefiltered interpolation.

This revealed various bugs:

* Prefiltering=False of linear interpolation was failing, because the
  prefilter=False option didn't make sense - because we were (correctly)
  not prefiltering.
* Use more standard TemporaryFile for backing store to avoid errors from
  too many open files.
* Avoid padding before prefiltering for Scipy < 1.6, because this gives
  different results from non-prefiltered case.

Also see #478