### PR TITLE
MRG: Fix for loss of revcmap in Matplotlib 3.4

### DIFF
--- a/nipy/labs/viz_tools/cm.py
+++ b/nipy/labs/viz_tools/cm.py
@@ -160,14 +160,11 @@ for _cmapname in list(_cmaps_data):
     if 'red' in _cmapspec:
         _cmap_d[_cmapname] = _colors.LinearSegmentedColormap(
             _cmapname, _cmapspec, _cm.LUTSIZE)
-        _reversed = _cmap_d[_cmapname].reversed(name=_cmapname_r)
-        _cmap_d[_cmapname_r] = _reversed
-        _cmaps_data[_cmapname_r] = _reversed._segmentdata.copy()
+        _cmap_d[_cmapname_r] = _cmap_d[_cmapname].reversed(name=_cmapname_r)
     else:
         _revspec = list(reversed(_cmapspec))
         if len(_revspec[0]) == 2:    # e.g., (1, (1.0, 0.0, 1.0))
             _revspec = [(1.0 - a, b) for a, b in _revspec]
-        _cmaps_data[_cmapname_r] = _revspec
 
         _cmap_d[_cmapname] = _colors.LinearSegmentedColormap.from_list(
                                 _cmapname, _cmapspec, _cm.LUTSIZE)

--- a/nipy/labs/viz_tools/cm.py
+++ b/nipy/labs/viz_tools/cm.py
@@ -158,12 +158,11 @@ for _cmapname in list(_cmaps_data):
     _cmapname_r = _cmapname + '_r'
     _cmapspec = _cmaps_data[_cmapname]
     if 'red' in _cmapspec:
-        _cmaps_data[_cmapname_r] = _cm.revcmap(_cmapspec)
         _cmap_d[_cmapname] = _colors.LinearSegmentedColormap(
-                                _cmapname, _cmapspec, _cm.LUTSIZE)
-        _cmap_d[_cmapname_r] = _colors.LinearSegmentedColormap(
-                                _cmapname_r, _cmaps_data[_cmapname_r],
-                                _cm.LUTSIZE)
+            _cmapname, _cmapspec, _cm.LUTSIZE)
+        _reversed = _cmap_d[_cmapname].reversed(name=_cmapname_r)
+        _cmap_d[_cmapname_r] = _reversed
+        _cmaps_data[_cmapname_r] = _reversed._segmentdata.copy()
     else:
         _revspec = list(reversed(_cmapspec))
         if len(_revspec[0]) == 2:    # e.g., (1, (1.0, 0.0, 1.0))


### PR DESCRIPTION
Matplotlib removed the `revcmap` function in 3.4, just released.

Rewrite using the `reversed` method of the colormap.

I'd love a review here.  Is there anyone out there who uses `labs.viz` that can
test this?