### PR TITLE
[MAINT] Fix depreciation warning

### DIFF
--- a/nipy/algorithms/statistics/models/model.py
+++ b/nipy/algorithms/statistics/models/model.py
@@ -6,7 +6,7 @@ from numpy.linalg import inv
 
 from scipy.stats import t as t_distribution
 
-from nibabel.onetime import setattr_on_read
+from nibabel.onetime import auto_attr
 
 from ...utils.matrices import pos_recipr
 
@@ -121,14 +121,14 @@ class LikelihoodModelResults(object):
         # put this as a parameter of LikelihoodModel
         self.df_resid = self.df_total - self.df_model
 
-    @setattr_on_read
+    @auto_attr
     def logL(self):
         """
         The maximized log-likelihood
         """
         return self.model.logL(self.theta, self.Y, nuisance=self.nuisance)
 
-    @setattr_on_read
+    @auto_attr
     def AIC(self):
         """
         Akaike Information Criterion
@@ -136,7 +136,7 @@ class LikelihoodModelResults(object):
         p = self.theta.shape[0]
         return -2 * self.logL + 2 * p
 
-    @setattr_on_read
+    @auto_attr
     def BIC(self):
         """
         Schwarz's Bayesian Information Criterion

--- a/nipy/algorithms/statistics/models/regression.py
+++ b/nipy/algorithms/statistics/models/regression.py
@@ -30,7 +30,7 @@ import numpy.linalg as npl
 from scipy import stats
 import scipy.linalg as spl
 
-from nibabel.onetime import setattr_on_read
+from nibabel.onetime import auto_attr
 
 from nipy.algorithms.utils.matrices import matrix_rank, pos_recipr
 
@@ -262,7 +262,7 @@ class OLSModel(LikelihoodModel):
         """
         return X
 
-    @setattr_on_read
+    @auto_attr
     def has_intercept(self):
         """
         Check if column of 1s is in column space of design
@@ -274,7 +274,7 @@ class OLSModel(LikelihoodModel):
             return True
         return False
 
-    @setattr_on_read
+    @auto_attr
     def rank(self):
         """ Compute rank of design matrix
         """
@@ -715,14 +715,14 @@ class RegressionResults(LikelihoodModelResults):
         self.wY = wY
         self.wresid = wresid
 
-    @setattr_on_read
+    @auto_attr
     def resid(self):
         """
         Residuals from the fit.
         """
         return self.Y - self.predicted
 
-    @setattr_on_read
+    @auto_attr
     def norm_resid(self):
         """
         Residuals, normalized to have unit length.
@@ -742,7 +742,7 @@ class RegressionResults(LikelihoodModelResults):
         """
         return self.resid * pos_recipr(np.sqrt(self.dispersion))
 
-    @setattr_on_read
+    @auto_attr
     def predicted(self):
         """ Return linear predictor values from a design matrix.
         """
@@ -751,7 +751,7 @@ class RegressionResults(LikelihoodModelResults):
         X = self.model.design
         return np.dot(X, beta)
 
-    @setattr_on_read
+    @auto_attr
     def R2_adj(self):
         """Return the R^2 value for each row of the response Y.
 
@@ -768,7 +768,7 @@ class RegressionResults(LikelihoodModelResults):
         d *= ((self.df_total - 1.) / self.df_resid)
         return 1 - d
 
-    @setattr_on_read
+    @auto_attr
     def R2(self):
         """
         Return the adjusted R^2 value for each row of the response Y.
@@ -782,7 +782,7 @@ class RegressionResults(LikelihoodModelResults):
         d = self.SSE / self.SST
         return 1 - d
 
-    @setattr_on_read
+    @auto_attr
     def SST(self):
         """Total sum of squares. If not from an OLS model this is "pseudo"-SST.
         """
@@ -791,34 +791,34 @@ class RegressionResults(LikelihoodModelResults):
                           "SST inappropriate")
         return ((self.wY - self.wY.mean(0)) ** 2).sum(0)
 
-    @setattr_on_read
+    @auto_attr
     def SSE(self):
         """Error sum of squares. If not from an OLS model this is "pseudo"-SSE.
         """
         return (self.wresid ** 2).sum(0)
 
-    @setattr_on_read
+    @auto_attr
     def SSR(self):
         """ Regression sum of squares """
         return self.SST - self.SSE
 
-    @setattr_on_read
+    @auto_attr
     def MSR(self):
         """ Mean square (regression)"""
         return self.SSR / (self.df_model - 1)
 
-    @setattr_on_read
+    @auto_attr
     def MSE(self):
         """ Mean square (error) """
         return self.SSE / self.df_resid
 
-    @setattr_on_read
+    @auto_attr
     def MST(self):
         """ Mean square (total)
         """
         return self.SST / (self.df_total - 1)
 
-    @setattr_on_read
+    @auto_attr
     def F_overall(self):
         """ Overall goodness of fit F test,
         comparing model to a model with just an intercept.

--- a/nipy/core/image/image.py
+++ b/nipy/core/image/image.py
@@ -19,7 +19,7 @@ from itertools import chain
 
 import numpy as np
 
-from nibabel.onetime import setattr_on_read
+from nibabel.onetime import auto_attr
 
 # These imports are used in the fromarray and subsample functions only, not in
 # Image
@@ -80,27 +80,27 @@ class Image(object):
                                np.diag([3,5,7,1]))
     _doc['coordmap'] = "Affine transform mapping from axes coordinates to reference coordinates."
 
-    @setattr_on_read
+    @auto_attr
     def shape(self):
         return self._data.shape
     _doc['shape'] = "Shape of data array."
 
-    @setattr_on_read
+    @auto_attr
     def ndim(self):
         return len(self._data.shape)
     _doc['ndim'] = "Number of data dimensions."
 
-    @setattr_on_read
+    @auto_attr
     def reference(self):
         return self.coordmap.function_range
     _doc['reference'] = "Reference coordinate system."
 
-    @setattr_on_read
+    @auto_attr
     def axes(self):
         return self.coordmap.function_domain
     _doc['axes'] = "Axes of image."
 
-    @setattr_on_read
+    @auto_attr
     def affine(self):
         if hasattr(self.coordmap, "affine"):
             return self.coordmap.affine


### PR DESCRIPTION
This is to address the following depreciation I was getting:

```
  File "/Users/alexrockhill/projects/mne-python/tutorials/clinical/10_ieeg_localize.py", line 33, in <module>
    from nipy.algorithms.registration.histogram_registration import (
  File "/Users/alexrockhill/software/anaconda3/envs/mne/lib/python3.9/site-packages/nipy/__init__.py", line 32, in <module>
    from nipy.io.api import load_image, save_image, as_image
  File "/Users/alexrockhill/software/anaconda3/envs/mne/lib/python3.9/site-packages/nipy/io/api.py", line 3, in <module>
    from .files import load as load_image, save as save_image, as_image
  File "/Users/alexrockhill/software/anaconda3/envs/mne/lib/python3.9/site-packages/nipy/io/files.py", line 22, in <module>
    from ..core.image.image import is_image
  File "/Users/alexrockhill/software/anaconda3/envs/mne/lib/python3.9/site-packages/nipy/core/image/__init__.py", line 13, in <module>
    from . import image
  File "/Users/alexrockhill/software/anaconda3/envs/mne/lib/python3.9/site-packages/nipy/core/image/image.py", line 34, in <module>
    class Image(object):
  File "/Users/alexrockhill/software/anaconda3/envs/mne/lib/python3.9/site-packages/nipy/core/image/image.py", line 84, in Image
    def shape(self):
  File "/Users/alexrockhill/software/anaconda3/envs/mne/lib/python3.9/site-packages/nibabel/deprecator.py", line 182, in deprecated_func
    warnings.warn(message, warn_class, stacklevel=2)
DeprecationWarning: setattr_on_read has been renamed to auto_attr. Please use nibabel.onetime.auto_attr

* deprecated from version: 3.2
* Will raise <class 'nibabel.deprecator.ExpiredDeprecationError'> as of version: 5.0
```

Looks like it should work by my testing the script it failed on.