### PR TITLE
Account for nibabel 5.0.0 removal of .py3k shim - use numpy.compat.py3k

### DIFF
--- a/nipy/algorithms/statistics/formula/tests/test_formula.py
+++ b/nipy/algorithms/statistics/formula/tests/test_formula.py
@@ -18,7 +18,7 @@ from .. import formulae as F
 from ..formulae import terms, Term
 from nipy.utils import VisibleDeprecationWarning
 
-from nibabel.py3k import asbytes
+from numpy.compat.py3k import asbytes
 from nibabel.testing import assert_dt_equal
 
 from nose.tools import (assert_true, assert_equal, assert_false,

--- a/nipy/core/image/image_spaces.py
+++ b/nipy/core/image/image_spaces.py
@@ -60,7 +60,7 @@ array([[ 2.,  0.,  0.,  0.],
 It also works with nibabel images, which can only have xyz_affines:
 
 >>> import nibabel as nib
->>> nimg = nib.Nifti1Image(data, affine)
+>>> nimg = nib.Nifti1Image(data, affine, dtype=data.dtype)
 >>> xyz_affine(nimg)
 array([[ 2.,  0.,  0.,  0.],
        [ 0.,  3.,  0.,  0.],
@@ -132,7 +132,7 @@ def xyz_affine(img, name2xyz=None):
     Nibabel images always have xyz affines
 
     >>> import nibabel as nib
-    >>> nimg = nib.Nifti1Image(arr, np.diag([2,3,4,1]))
+    >>> nimg = nib.Nifti1Image(arr, np.diag([2,3,4,1]), dtype=arr.dtype)
     >>> xyz_affine(nimg)
     array([[ 2.,  0.,  0.,  0.],
            [ 0.,  3.,  0.,  0.],
@@ -195,7 +195,7 @@ def is_xyz_affable(img, name2xyz=None):
     Nibabel images always have xyz affines
 
     >>> import nibabel as nib
-    >>> nimg = nib.Nifti1Image(arr, np.diag([2,3,4,1]))
+    >>> nimg = nib.Nifti1Image(arr, np.diag([2,3,4,1]), dtype=arr.dtype)
     >>> is_xyz_affable(nimg)
     True
     """

--- a/nipy/core/image/tests/test_image_spaces.py
+++ b/nipy/core/image/tests/test_image_spaces.py
@@ -34,7 +34,7 @@ def test_image_xyz_affine():
     img4_r = img4.reordered_axes([3,2,0,1])
     assert_false(is_xyz_affable(img4_r))
     assert_raises(AxesError, xyz_affine, img4_r)
-    nimg = nib.Nifti1Image(arr, aff)
+    nimg = nib.Nifti1Image(arr, aff, dtype=arr.dtype)
     assert_true(is_xyz_affable(nimg))
     assert_array_equal(xyz_affine(nimg), aff)
     # Any dimensions not spatial, AxesError
@@ -77,7 +77,7 @@ def test_image_as_xyz_image():
     assert_array_equal(img.get_data(), img_t0_r.get_data())
     assert_equal(img.coordmap, img_t0_r.coordmap)
     # Test against nibabel image
-    nimg = nib.Nifti1Image(arr, np.diag([2,3,4,1]))
+    nimg = nib.Nifti1Image(arr, np.diag([2,3,4,1]), dtype=arr.dtype)
     nimg_r = as_xyz_image(nimg)
     assert_true(nimg is nimg_r)
     # It's sometimes impossible to make an xyz affable image

--- a/nipy/io/tests/test_image_io.py
+++ b/nipy/io/tests/test_image_io.py
@@ -44,7 +44,7 @@ def test_badfile():
     # nibabel prior 2.1.0 was throwing a ImageFileError for the not-recognized
     # file type.  >=2.1.0 give a FileNotFoundError.
     try:
-        from nibabel.py3k import FileNotFoundError
+        from numpy.compat.py3k import FileNotFoundError
     except ImportError:
         FileNotFoundError = IOError
     assert_raises((ImageFileError, FileNotFoundError), load_image, filename)

--- a/nipy/labs/spatial_models/parcel_io.py
+++ b/nipy/labs/spatial_models/parcel_io.py
@@ -54,7 +54,8 @@ def mask_parcellation(mask_images, nb_parcel, threshold=0, output_image=None):
         # mask_images should be a list
         mask_data = intersect_masks(mask_images, threshold=0) > 0
         mask = Nifti1Image(mask_data.astype('u8'),
-                           get_affine(load(mask_images[0])))
+                           get_affine(load(mask_images[0])),
+                           dtype=mask_data.astype('u8').dtype)
 
     domain = grid_domain_from_image(mask)
     cent, labels, J = kmeans(domain.coord, nb_parcel)
@@ -100,7 +101,8 @@ def parcel_input(mask_images, learning_images, ths=.5, fdim=None):
         # mask_images should be a list
         grp_mask = intersect_masks(mask_images, threshold=ths) > 0
         mask = Nifti1Image(grp_mask.astype('u8'),
-                           get_affine(load(mask_images[0])))
+                           get_affine(load(mask_images[0])),
+                           dtype=grp_mask.astype('u8').dtype)
 
     # build the domain
     domain = grid_domain_from_image(mask, nn=6)

--- a/nipy/labs/spatial_models/tests/test_discrete_domain.py
+++ b/nipy/labs/spatial_models/tests/test_discrete_domain.py
@@ -130,7 +130,7 @@ def test_image_domain():
     toto = np.ones(shape[:3])
     affine = np.random.randn(4, 4)
     affine[3:, 0:3] = 0
-    nim = Nifti1Image(toto, affine)
+    nim = Nifti1Image(toto, affine, dtype=toto.dtype)
     ddom = domain_from_image(nim)
     ref = np.sum(toto) * np.absolute(np.linalg.det(affine))
     assert_almost_equal(np.sum(ddom.local_volume), ref)
@@ -142,8 +142,8 @@ def test_image_feature():
     mask = np.random.randn(*shape[:3]) > .5
     noise = np.random.randn(*shape[:3])
     affine = np.eye(4)
-    mim = Nifti1Image(mask.astype('u8'), affine)
-    nim = Nifti1Image(noise, affine)
+    mim = Nifti1Image(mask.astype('u8'), affine, dtype=mask.astype('u8').dtype)
+    nim = Nifti1Image(noise, affine, dtype=noise.dtype)
     ddom = grid_domain_from_image(mim)
     ddom.make_feature_from_image(nim, 'noise')
     assert_almost_equal(ddom.features['noise'], noise[mask])
@@ -163,7 +163,7 @@ def test_image_grid_domain():
     toto = np.ones(shape[:3])
     affine = np.random.randn(4, 4)
     affine[3:, 0:3] = 0
-    nim = Nifti1Image(toto, affine)
+    nim = Nifti1Image(toto, affine, dtype=toto.dtype)
     ddom = grid_domain_from_image(nim)
     ref = np.sum(toto) * np.absolute(np.linalg.det(affine[:3, 0:3]))
     assert_almost_equal(np.sum(ddom.local_volume), ref)

--- a/nipy/labs/spatial_models/tests/test_mroi.py
+++ b/nipy/labs/spatial_models/tests/test_mroi.py
@@ -205,8 +205,10 @@ def test_example():
     # Test example runs correctly
     eg_img = pjoin(dirname(__file__), 'some_blobs.nii')
     nim = load(eg_img)
-    mask_image = Nifti1Image((nim.get_data() ** 2 > 0).astype('u8'),
-                             get_affine(nim))
+    arr = nim.get_data() ** 2 > 0
+    mask_image = Nifti1Image(arr.astype('u8'),
+                             get_affine(nim),
+                             dtype=arr.astype('u8').dtype)
     domain = grid_domain_from_image(mask_image)
     data = nim.get_data()
     values = data[data != 0]

--- a/nipy/labs/spatial_models/tests/test_parcel_io.py
+++ b/nipy/labs/spatial_models/tests/test_parcel_io.py
@@ -17,7 +17,9 @@ def test_mask_parcel():
     """
     n_parcels = 20
     shape = (10, 10, 10)
-    mask_image = Nifti1Image(np.ones(shape), np.eye(4))
+    mask_image = Nifti1Image(np.ones(shape),
+                             np.eye(4),
+                             dtype=np.ones(shape).dtype)
     wim = mask_parcellation(mask_image, n_parcels)
     assert_equal(np.unique(wim.get_data()), np.arange(n_parcels))
 
@@ -33,8 +35,10 @@ def test_mask_parcel_multi_subj():
     with InTemporaryDirectory():
         for subject in range(n_subjects):
             path = 'mask%s.nii' % subject
-            save(Nifti1Image((rng.rand(*shape) > .1).astype('u8'),
-                             np.eye(4)), path)
+            arr = rng.rand(*shape) > .1
+            save(Nifti1Image(arr.astype('u8'), np.eye(4),
+                             dtype=arr.astype('u8').dtype),
+                 path)
             mask_images.append(path)
 
         wim = mask_parcellation(mask_images, n_parcels)
@@ -47,7 +51,8 @@ def test_parcel_intra_from_3d_image():
     # Generate an image
     shape = (10, 10, 10)
     n_parcel, nn, mu = 10, 6, 1.
-    mask_image = Nifti1Image(np.ones(shape), np.eye(4))
+    mask_image = Nifti1Image(np.ones(shape), np.eye(4),
+                             dtype=np.ones(shape).dtype)
     with InTemporaryDirectory() as dir_context:
         surrogate_3d_dataset(mask=mask_image, out_image_file='image.nii')
 
@@ -67,7 +72,8 @@ def test_parcel_intra_from_3d_images_list():
     shape = (10, 10, 10)
     n_parcel, nn, mu = 10, 6, 1.
     method = 'ward'
-    mask_image = Nifti1Image(np.ones(shape), np.eye(4))
+    mask_image = Nifti1Image(np.ones(shape), np.eye(4),
+                             dtype=np.ones(shape).dtype)
 
     with InTemporaryDirectory() as dir_context:
         data_image = ['image_%d.nii' % i for i in range(5)]
@@ -88,7 +94,8 @@ def test_parcel_intra_from_4d_image():
     shape = (10, 10, 10)
     n_parcel, nn, mu = 10, 6, 1.
     method = 'ward'
-    mask_image = Nifti1Image(np.ones(shape), np.eye(4))
+    mask_image = Nifti1Image(np.ones(shape), np.eye(4),
+                             dtype=np.ones(shape).dtype)
     with InTemporaryDirectory() as dir_context:
         surrogate_3d_dataset(n_subj=10, mask=mask_image, 
                              out_image_file='image.nii')    

--- a/nipy/utils/compat3.py
+++ b/nipy/utils/compat3.py
@@ -1,6 +1,6 @@
 """ Routines for Python 3 compatibility
 
-These are in addition to the nibabel.py3k routines.
+These are in addition to the numpy.compat.py3k routines.
 """
 from __future__ import absolute_import
 

--- a/nipy/utils/tests/test_compat3.py
+++ b/nipy/utils/tests/test_compat3.py
@@ -3,7 +3,7 @@
 from __future__ import with_statement
 from __future__ import absolute_import
 
-from nibabel.py3k import asstr, asbytes
+from numpy.compat.py3k import asstr, asbytes
 
 from ..compat3 import to_str, open4csv
 

--- a/tools/run_log_examples.py
+++ b/tools/run_log_examples.py
@@ -25,7 +25,7 @@ from os.path import (abspath, expanduser, join as pjoin, sep as psep, isfile,
 from subprocess import Popen, PIPE
 import re
 
-from nibabel.py3k import asstr
+from numpy.compat.py3k import asstr
 
 from nipy.externals.argparse import (ArgumentParser,
                                      RawDescriptionHelpFormatter)


### PR DESCRIPTION
Includes some other fixes found in the patch prepared by @emollier (thanks!) in Debian:
https://salsa.debian.org/med-team/nipy/-/blob/master/debian/patches/nibabel5.0.0.patch