### PR TITLE
Explicitly import sphinx.ext.doctest

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,7 @@ import sys, os
 from importlib import import_module
 
 import sphinx
+import sphinx.ext.doctest
 
 # Doc generation depends on being able to import project
 project = 'nipy'


### PR DESCRIPTION
In later versions of Sphinx, we cannot assume that we can use “sphinx.ext.doctest.doctest” after “import sphinx”.

I know that the Sphinx version is upper-bounded, but this does no harm and helps with forward-compatibility.