### PR TITLE
MNT: Update build tools to work with modern pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = [
+  "setuptools",
+  "cython",
+  # Newer than NEP29-minimum: compile against oldest numpy available
+  "numpy==1.24; python_version >= '3.11'",
+  "numpy==1.22; python_version >= '3.10' and python_version < '3.11'",
+  # NEP29-minimum as of Jan 31, 2023
+  "numpy==1.21; python_version >= '3.7' and python_version < '3.10'",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
+import sys
 import os
 from os.path import join as pjoin, exists
 from glob import glob
 from distutils import log
 
-# BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
-# update it when the contents of directories change.
-if exists('MANIFEST'): os.remove('MANIFEST')
-
 # Always use setuptools
 import setuptools
+
+sys.path.append('.')
 
 from setup_helpers import (generate_a_pyrex_source, get_comrec_build,
                            cmdclass, INFO_VARS)


### PR DESCRIPTION
Pip uses build isolation by default. This adds a `pyproject.toml` to declare the build-time dependencies. It also tweaks the `sys.path` in `setup.py` to ensure that `setup_helpers` can be imported in an isolated environment.

There's a lot more that needs removing to cope with the upcoming 3.12 removal of distutils, but this is a short-term plug that moves things in the right direction.

nipy/nitime#199 added `cibuildwheel`. I could do that in a separate PR if desired.