### PR TITLE
Don’t use nose.tools.assert_equals

### DIFF
--- a/nipy/labs/datasets/tests/test_converters.py
+++ b/nipy/labs/datasets/tests/test_converters.py
@@ -18,9 +18,9 @@ def test_conversion():
 
     brifti_obj = nib.load(data_file)
     vol_img = as_volume_img(data_file)
-    yield nose.tools.assert_equals, as_volume_img(vol_img), \
+    yield nose.tools.assert_equal, as_volume_img(vol_img), \
                     vol_img
-    yield nose.tools.assert_equals, as_volume_img(brifti_obj), \
+    yield nose.tools.assert_equal, as_volume_img(brifti_obj), \
                     vol_img
 
 
@@ -42,7 +42,7 @@ try:
     import nifti
     def test_from_nifti():
         nim = nifti.NiftiImage(data_file)
-        yield nose.tools.assert_equals, as_volume_img(data_file), \
+        yield nose.tools.assert_equal, as_volume_img(data_file), \
                     as_volume_img(nim)
 
 except ImportError:


### PR DESCRIPTION
Use `nose.tools.assert_equal` instead.

Since `unittest.TestCase.assertEquals` is a deprecated alias for `unittest.TestCase.TestCase.assertEqual`, and is removed in Python 3.12, and since the `nose.tools` assertion names are apparently automagically generated from the `unittest.TestCase` assertion methods, `nose.tools.assert_equals` is also removed in Python 3.12 (when `nose` is otherwise patched to work with Python 3.12).