### PR TITLE
Account for nibabel 5.0.0 removal of .py3k shim - use numpy.compat.py3k

### DIFF
--- a/nipy/algorithms/statistics/formula/tests/test_formula.py
+++ b/nipy/algorithms/statistics/formula/tests/test_formula.py
@@ -18,7 +18,7 @@ from .. import formulae as F
 from ..formulae import terms, Term
 from nipy.utils import VisibleDeprecationWarning
 
-from nibabel.py3k import asbytes
+from numpy.compat.py3k import asbytes
 from nibabel.testing import assert_dt_equal
 
 from nose.tools import (assert_true, assert_equal, assert_false,

--- a/nipy/algorithms/statistics/formula/tests/test_formula.py
+++ b/nipy/algorithms/statistics/formula/tests/test_formula.py
@@ -18,7 +18,6 @@ from .. import formulae as F
 from ..formulae import terms, Term
 from nipy.utils import VisibleDeprecationWarning
 
-from numpy.compat.py3k import asbytes
 from nibabel.testing import assert_dt_equal
 
 from nose.tools import (assert_true, assert_equal, assert_false,
@@ -364,7 +363,7 @@ def test_formula_inputs():
         f = F.Factor('myname', levels)
         assert_equal(f.levels, level_names)
     # Sending in byte objects
-    levels = [asbytes(L) for L in level_names]
+    levels = [L.encode() for L in level_names]
     f = F.Factor('myname', levels)
     assert_equal(f.levels, level_names)
 

--- a/nipy/core/image/image_spaces.py
+++ b/nipy/core/image/image_spaces.py
@@ -60,7 +60,7 @@ array([[ 2.,  0.,  0.,  0.],
 It also works with nibabel images, which can only have xyz_affines:
 
 >>> import nibabel as nib
->>> nimg = nib.Nifti1Image(data, affine)
+>>> nimg = nib.Nifti1Image(data.astype('float'), affine)
 >>> xyz_affine(nimg)
 array([[ 2.,  0.,  0.,  0.],
        [ 0.,  3.,  0.,  0.],
@@ -195,7 +195,7 @@ def is_xyz_affable(img, name2xyz=None):
     Nibabel images always have xyz affines
 
     >>> import nibabel as nib
-    >>> nimg = nib.Nifti1Image(arr, np.diag([2,3,4,1]))
+    >>> nimg = nib.Nifti1Image(arr.astype('float'), np.diag([2,3,4,1]))
     >>> is_xyz_affable(nimg)
     True
     """

--- a/nipy/core/image/image_spaces.py
+++ b/nipy/core/image/image_spaces.py
@@ -18,7 +18,7 @@ Make a standard 4D xyzt image in MNI space.
 
 First the data and affine:
 
->>> data = np.arange(24).reshape((1,2,3,4))
+>>> data = np.arange(24, dtype=np.float32).reshape((1,2,3,4))
 >>> affine = np.diag([2,3,4,1]).astype(float)
 
 We can add the TR (==2.0) to make the full 5x5 affine we need
@@ -60,7 +60,7 @@ array([[ 2.,  0.,  0.,  0.],
 It also works with nibabel images, which can only have xyz_affines:
 
 >>> import nibabel as nib
->>> nimg = nib.Nifti1Image(data.astype('float'), affine)
+>>> nimg = nib.Nifti1Image(data, affine)
 >>> xyz_affine(nimg)
 array([[ 2.,  0.,  0.,  0.],
        [ 0.,  3.,  0.,  0.],

--- a/nipy/core/image/tests/test_image_spaces.py
+++ b/nipy/core/image/tests/test_image_spaces.py
@@ -34,7 +34,7 @@ def test_image_xyz_affine():
     img4_r = img4.reordered_axes([3,2,0,1])
     assert_false(is_xyz_affable(img4_r))
     assert_raises(AxesError, xyz_affine, img4_r)
-    nimg = nib.Nifti1Image(arr, aff)
+    nimg = nib.Nifti1Image(arr.astype('float'), aff)
     assert_true(is_xyz_affable(nimg))
     assert_array_equal(xyz_affine(nimg), aff)
     # Any dimensions not spatial, AxesError
@@ -77,7 +77,7 @@ def test_image_as_xyz_image():
     assert_array_equal(img.get_fdata(), img_t0_r.get_fdata())
     assert_equal(img.coordmap, img_t0_r.coordmap)
     # Test against nibabel image
-    nimg = nib.Nifti1Image(arr, np.diag([2,3,4,1]))
+    nimg = nib.Nifti1Image(arr.astype('float'), np.diag([2,3,4,1]))
     nimg_r = as_xyz_image(nimg)
     assert_true(nimg is nimg_r)
     # It's sometimes impossible to make an xyz affable image

--- a/nipy/io/tests/test_image_io.py
+++ b/nipy/io/tests/test_image_io.py
@@ -45,7 +45,7 @@ def test_badfile():
     # nibabel prior 2.1.0 was throwing a ImageFileError for the not-recognized
     # file type.  >=2.1.0 give a FileNotFoundError.
     try:
-        from nibabel.py3k import FileNotFoundError
+        from numpy.compat.py3k import FileNotFoundError
     except ImportError:
         FileNotFoundError = IOError
     assert_raises((ImageFileError, FileNotFoundError), load_image, filename)

--- a/nipy/io/tests/test_image_io.py
+++ b/nipy/io/tests/test_image_io.py
@@ -44,10 +44,6 @@ def test_badfile():
     filename = "bad_file.foo"
     # nibabel prior 2.1.0 was throwing a ImageFileError for the not-recognized
     # file type.  >=2.1.0 give a FileNotFoundError.
-    try:
-        from numpy.compat.py3k import FileNotFoundError
-    except ImportError:
-        FileNotFoundError = IOError
     assert_raises((ImageFileError, FileNotFoundError), load_image, filename)
 
 

--- a/nipy/labs/spatial_models/parcel_io.py
+++ b/nipy/labs/spatial_models/parcel_io.py
@@ -53,7 +53,7 @@ def mask_parcellation(mask_images, nb_parcel, threshold=0, output_image=None):
     else:
         # mask_images should be a list
         mask_data = intersect_masks(mask_images, threshold=0) > 0
-        mask = Nifti1Image(mask_data.astype('u8'),
+        mask = Nifti1Image(mask_data.astype('u1'),
                            get_affine(load(mask_images[0])))
 
     domain = grid_domain_from_image(mask)
@@ -99,7 +99,7 @@ def parcel_input(mask_images, learning_images, ths=.5, fdim=None):
     else:
         # mask_images should be a list
         grp_mask = intersect_masks(mask_images, threshold=ths) > 0
-        mask = Nifti1Image(grp_mask.astype('u8'),
+        mask = Nifti1Image(grp_mask.astype('u1'),
                            get_affine(load(mask_images[0])))
 
     # build the domain

--- a/nipy/labs/spatial_models/tests/test_discrete_domain.py
+++ b/nipy/labs/spatial_models/tests/test_discrete_domain.py
@@ -142,7 +142,7 @@ def test_image_feature():
     mask = np.random.randn(*shape[:3]) > .5
     noise = np.random.randn(*shape[:3])
     affine = np.eye(4)
-    mim = Nifti1Image(mask.astype('u8'), affine)
+    mim = Nifti1Image(mask.astype('u1'), affine)
     nim = Nifti1Image(noise, affine)
     ddom = grid_domain_from_image(mim)
     ddom.make_feature_from_image(nim, 'noise')

--- a/nipy/labs/spatial_models/tests/test_mroi.py
+++ b/nipy/labs/spatial_models/tests/test_mroi.py
@@ -205,8 +205,8 @@ def test_example():
     # Test example runs correctly
     eg_img = pjoin(dirname(__file__), 'some_blobs.nii')
     nim = load(eg_img)
-    mask_image = Nifti1Image((nim.get_fdata() ** 2 > 0).astype('u8'),
-                             get_affine(nim))
+    arr = nim.get_fdata() ** 2 > 0
+    mask_image = Nifti1Image(arr.astype('u1'), get_affine(nim))
     domain = grid_domain_from_image(mask_image)
     data = nim.get_fdata()
     values = data[data != 0]

--- a/nipy/labs/spatial_models/tests/test_parcel_io.py
+++ b/nipy/labs/spatial_models/tests/test_parcel_io.py
@@ -17,7 +17,7 @@ def test_mask_parcel():
     """
     n_parcels = 20
     shape = (10, 10, 10)
-    mask_image = Nifti1Image(np.ones(shape), np.eye(4))
+    mask_image = Nifti1Image(np.ones(shape).astype('u1'), np.eye(4))
     wim = mask_parcellation(mask_image, n_parcels)
     assert_equal(np.unique(wim.get_fdata()), np.arange(n_parcels))
 
@@ -33,8 +33,8 @@ def test_mask_parcel_multi_subj():
     with InTemporaryDirectory():
         for subject in range(n_subjects):
             path = 'mask%s.nii' % subject
-            save(Nifti1Image((rng.rand(*shape) > .1).astype('u8'),
-                             np.eye(4)), path)
+            arr = rng.rand(*shape) > .1
+            save(Nifti1Image(arr.astype('u1'), np.eye(4)), path)
             mask_images.append(path)
 
         wim = mask_parcellation(mask_images, n_parcels)
@@ -47,7 +47,7 @@ def test_parcel_intra_from_3d_image():
     # Generate an image
     shape = (10, 10, 10)
     n_parcel, nn, mu = 10, 6, 1.
-    mask_image = Nifti1Image(np.ones(shape), np.eye(4))
+    mask_image = Nifti1Image(np.ones(shape).astype('u1'), np.eye(4))
     with InTemporaryDirectory() as dir_context:
         surrogate_3d_dataset(mask=mask_image, out_image_file='image.nii')
 
@@ -67,7 +67,7 @@ def test_parcel_intra_from_3d_images_list():
     shape = (10, 10, 10)
     n_parcel, nn, mu = 10, 6, 1.
     method = 'ward'
-    mask_image = Nifti1Image(np.ones(shape), np.eye(4))
+    mask_image = Nifti1Image(np.ones(shape).astype('u1'), np.eye(4))
 
     with InTemporaryDirectory() as dir_context:
         data_image = ['image_%d.nii' % i for i in range(5)]
@@ -88,7 +88,7 @@ def test_parcel_intra_from_4d_image():
     shape = (10, 10, 10)
     n_parcel, nn, mu = 10, 6, 1.
     method = 'ward'
-    mask_image = Nifti1Image(np.ones(shape), np.eye(4))
+    mask_image = Nifti1Image(np.ones(shape).astype('u1'), np.eye(4))
     with InTemporaryDirectory() as dir_context:
         surrogate_3d_dataset(n_subj=10, mask=mask_image, 
                              out_image_file='image.nii')    

--- a/nipy/utils/compat3.py
+++ b/nipy/utils/compat3.py
@@ -1,6 +1,6 @@
 """ Routines for Python 3 compatibility
 
-These are in addition to the nibabel.py3k routines.
+These are in addition to the numpy.compat.py3k routines.
 """
 from __future__ import absolute_import
 

--- a/nipy/utils/tests/test_compat3.py
+++ b/nipy/utils/tests/test_compat3.py
@@ -3,8 +3,6 @@
 from __future__ import with_statement
 from __future__ import absolute_import
 
-from numpy.compat.py3k import asstr, asbytes
-
 from ..compat3 import to_str, open4csv
 
 from nose.tools import (assert_true, assert_false, assert_raises,
@@ -17,8 +15,8 @@ def test_to_str():
     # Test routine to convert to string
     assert_equal('1', to_str(1))
     assert_equal('1.0', to_str(1.0))
-    assert_equal('from', to_str(asstr('from')))
-    assert_equal('from', to_str(asbytes('from')))
+    assert_equal('from', to_str('from'))
+    assert_equal('from', to_str('from'.encode()))
 
 
 def test_open4csv():

--- a/nipy/utils/tests/test_compat3.py
+++ b/nipy/utils/tests/test_compat3.py
@@ -3,7 +3,7 @@
 from __future__ import with_statement
 from __future__ import absolute_import
 
-from nibabel.py3k import asstr, asbytes
+from numpy.compat.py3k import asstr, asbytes
 
 from ..compat3 import to_str, open4csv
 

--- a/tools/run_log_examples.py
+++ b/tools/run_log_examples.py
@@ -25,7 +25,7 @@ from os.path import (abspath, expanduser, join as pjoin, sep as psep, isfile,
 from subprocess import Popen, PIPE
 import re
 
-from nibabel.py3k import asstr
+from numpy.compat.py3k import asstr
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 

--- a/tools/run_log_examples.py
+++ b/tools/run_log_examples.py
@@ -25,8 +25,6 @@ from os.path import (abspath, expanduser, join as pjoin, sep as psep, isfile,
 from subprocess import Popen, PIPE
 import re
 
-from numpy.compat.py3k import asstr
-
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 
@@ -85,7 +83,7 @@ class ProcLogger(object):
         finally:
             if proc.poll() is None: # In case we get killed
                 proc.terminate()
-        return asstr(stdout), asstr(stderr), proc.returncode
+        return stdout.decode(), stderr.decode(), proc.returncode
 
 
 class PyProcLogger(ProcLogger):


### PR DESCRIPTION
Rebased from:

https://salsa.debian.org/med-team/nipy/-/blob/12a4fbea8c99c1e5dc07ee81bc3da1a450617050/debian/patches/nibabel5.0.0.patch

This is a version of https://github.com/nipy/nipy/pull/498 that applies cleanly and seems to work as expected in Fedora Linux. Please see the original PR for discussion.