### PR TITLE
Fix test creating unsupported double-precision GiftiDataArray

### DIFF
--- a/nipy/labs/spatial_models/tests/test_discrete_domain.py
+++ b/nipy/labs/spatial_models/tests/test_discrete_domain.py
@@ -227,7 +227,8 @@ def test_domain_from_mesh():
                             [0, 1, 3],
                             [0, 2, 3],
                             [1, 2, 3]])
-    darrays = [nbg.GiftiDataArray(coords)] + [nbg.GiftiDataArray(triangles)]
+    darrays = [nbg.GiftiDataArray(coords, datatype='NIFTI_TYPE_FLOAT32'),
+               nbg.GiftiDataArray(triangles, datatype='NIFTI_TYPE_INT32')]
     toy_image = nbg.GiftiImage(darrays=darrays)
     domain = domain_from_mesh(toy_image)
     # if we get there, we could build the domain, and that's what we wanted.


### PR DESCRIPTION
See:

https://github.com/nipy/nibabel/issues/1198
https://github.com/nipy/nibabel/pull/1199
https://github.com/nilearn/nilearn/pull/3649