### PR TITLE
MNT: Update build requirements to use numpy 1.25 and cython<3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
 requires = [
   "setuptools",
-  "cython",
+  "cython<3",
   # Newer than NEP29-minimum: compile against oldest numpy available
-  "numpy==1.24; python_version >= '3.11'",
-  "numpy==1.22; python_version >= '3.10' and python_version < '3.11'",
-  # NEP29-minimum as of Jan 31, 2023
-  "numpy==1.21; python_version >= '3.7' and python_version < '3.10'",
+  "numpy>=1.25; python_version > '3.8'",
+  # NEP29-minimum as of Sep 21, 2023
+  "numpy==1.22; python_version >= '3.7' and python_version < '3.9'",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixes #508 and simplifies the build logic a bit, thanks to backwards-compatible numpy builds (see https://numpy.org/doc/stable/release/1.25.0-notes.html#compiling-against-the-numpy-c-api-is-now-backwards-compatible-by-default).