### PR TITLE
Drop the PyPI mock dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Tests
 To run nipy's tests, you will need to install the nose_ Python testing
 package::
 
-    pip install nose
+    pip install nose3
 
 Then::
 

--- a/README.rst
+++ b/README.rst
@@ -74,10 +74,9 @@ Tests
 =====
 
 To run nipy's tests, you will need to install the nose_ Python testing
-package.  If you are using Python 2.7, you will also need to install the mock_
-testing package - e.g.::
+package::
 
-    pip install nose mock
+    pip install nose
 
 Then::
 
@@ -112,5 +111,4 @@ the nipy distribution.
 .. _ipython: http://ipython.org
 .. _matplotlib: http://matplotlib.org
 .. _nose: http://nose.readthedocs.org/en/latest
-.. _mock: https://pypi.python.org/pypi/mock
 .. _installation instructions: http://nipy.org/nipy/users/installation.html

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
 # Requirements for running tests
 -r requirements.txt
 nose3
-mock

--- a/nipy/info.py
+++ b/nipy/info.py
@@ -104,6 +104,9 @@ Tests
 To run nipy's tests, you will need to install the nose_ Python testing
 package::
 
+    pip install nose3
+
+
 Then::
 
     python -c "import nipy; nipy.test()"

--- a/nipy/info.py
+++ b/nipy/info.py
@@ -102,10 +102,7 @@ Tests
 =====
 
 To run nipy's tests, you will need to install the nose_ Python testing
-package.  If you are using Python 2.7, you will also need to install the mock_
-testing package - e.g.::
-
-    pip install nose mock
+package::
 
 Then::
 
@@ -140,7 +137,6 @@ the nipy distribution.
 .. _ipython: http://ipython.org
 .. _matplotlib: http://matplotlib.org
 .. _nose: http://nose.readthedocs.org/en/latest
-.. _mock: https://pypi.python.org/pypi/mock
 .. _six: https://six.readthedocs.io
 .. _installation instructions: http://nipy.org/nipy/users/installation.html
 """


### PR DESCRIPTION
This was only needed for Python 2.7, which `nipy` will no longer support (https://github.com/nipy/nipy/pull/512#discussion_r1333271211).