### PR TITLE
Replace doc-files with doc_files in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@
 #build_sphinx = build_sphinx zip_help
 
 [bdist_rpm]
-doc-files = doc
+doc_files = doc
 
 [nosetests]
 verbosity = 2


### PR DESCRIPTION
Fixes:

```
        ********************************************************************************
        Usage of dash-separated doc-files will not be supported in future
        versions. Please use the underscore name doc_files instead.

        By 2023-Sep-26, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************
```