### PR TITLE
Do not compare strings by identity (address)

### DIFF
--- a/nipy/labs/glm/glm.py
+++ b/nipy/labs/glm/glm.py
@@ -146,7 +146,7 @@ class contrast:
         self.variance = None
         self.dof = None
         if dim > 1:
-            if type is 't':
+            if type == 't':
                 type = 'F'
         self.type = type
         self._stat = None

--- a/nipy/labs/spatial_models/parcel_io.py
+++ b/nipy/labs/spatial_models/parcel_io.py
@@ -218,7 +218,7 @@ def parcellation_based_analysis(Pa, test_images, test_id='one_sample',
                      for ti in test_images]).T
     test_data = Pa.make_feature('', np.array(test))
 
-    if test_id is not 'one_sample':
+    if test_id != 'one_sample':
         return test_data
 
     # 2. perform one-sample test
@@ -285,7 +285,7 @@ def fixed_parcellation(mask_image, betas, nbparcel, nn=6, method='ward',
     # 1.1 the domain
     domain = grid_domain_from_image(mask_image, nn)
 
-    if method is not 'kmeans':
+    if method != 'kmeans':
         # 1.2 get the main cc of the graph
         # to remove the small connected components
         pass
@@ -305,7 +305,7 @@ def fixed_parcellation(mask_image, betas, nbparcel, nn=6, method='ward',
 
     #step 2: parcellate the data ---------------------------
 
-    if method is not 'kmeans':
+    if method != 'kmeans':
         g = field_from_coo_matrix_and_data(domain.topology, feature)
 
     if method == 'kmeans':

--- a/nipy/labs/utils/reproducibility_measures.py
+++ b/nipy/labs/utils/reproducibility_measures.py
@@ -665,7 +665,7 @@ def group_reproducibility_metrics(
 
     from ..mask import intersect_masks
 
-    if ((len(variance_images) == 0) & (method != 'crfx')):
+    if len(variance_images) == 0 and method != 'crfx':
         raise ValueError('Variance images are necessary')
 
     nsubj = len(contrast_images)

--- a/nipy/labs/utils/reproducibility_measures.py
+++ b/nipy/labs/utils/reproducibility_measures.py
@@ -438,7 +438,7 @@ def map_reproducibility(data, vardata, domain, ngroups, method='crfx',
             # randomly swap the sign of x
             x *= (2 * (np.random.rand(len(samples[i])) > 0.5) - 1)
 
-        if method is not 'crfx':
+        if method != 'crfx':
             vx = vardata[:, samples[i]]
         csize = kwargs['csize']
         threshold = kwargs['threshold']
@@ -506,9 +506,9 @@ def peak_reproducibility(data, vardata, domain, ngroups, sigma, method='crfx',
             # apply a random sign swap to x
             x *= (2 * (np.random.rand(len(samples[i])) > 0.5) - 1)
 
-        if method is not 'crfx':
+        if method != 'crfx':
             vx = vardata[:, samples[i]]
-        if method is not 'bsa':
+        if method != 'bsa':
             threshold = kwargs['threshold']
 
             if method == 'crfx':
@@ -594,9 +594,9 @@ def cluster_reproducibility(data, vardata, domain, ngroups, sigma,
             # apply a random sign swap to x
             x *= (2 * (np.random.rand(len(samples[i])) > 0.5) - 1)
 
-        if method is not 'crfx':
+        if method != 'crfx':
             vx = vardata[:, samples[i]]
-        if method is not 'bsa':
+        if method != 'bsa':
             csize = kwargs['csize']
             threshold = kwargs['threshold']
             if method == 'crfx':
@@ -665,7 +665,7 @@ def group_reproducibility_metrics(
 
     from ..mask import intersect_masks
 
-    if ((len(variance_images) == 0) & (method is not 'crfx')):
+    if ((len(variance_images) == 0) & (method != 'crfx')):
         raise ValueError('Variance images are necessary')
 
     nsubj = len(contrast_images)


### PR DESCRIPTION
These comparisons against string literals may work in practice due to implementation details of string interning in CPython, but they are not reliable or correct, and they produce a `SyntaxWarning` in Python 3.12. Strings should always be compared by value (`==`/`!=`) rather than identity (`is`/`is not`).