### PR TITLE
Fix backslash escaping issues in docstrings

### DIFF
--- a/nipy/algorithms/statistics/formula/formulae.py
+++ b/nipy/algorithms/statistics/formula/formulae.py
@@ -215,7 +215,7 @@ def terms(names, **kwargs):
     names : str or sequence of str
        If a single str, can specify multiple ``Term``s with string
        containing space or ',' as separator.
-    \**kwargs : keyword arguments
+    \*\*kwargs : keyword arguments
        keyword arguments as for ``sympy.symbols``
 
     Returns

--- a/nipy/algorithms/statistics/formula/formulae.py
+++ b/nipy/algorithms/statistics/formula/formulae.py
@@ -202,7 +202,7 @@ T = Term('t')
 
 
 def terms(names, **kwargs):
-    ''' Return list of terms with names given by `names`
+    r''' Return list of terms with names given by `names`
 
     This is just a convenience in defining a set of terms, and is the
     equivalent of ``sympy.symbols`` for defining symbols in sympy.
@@ -215,7 +215,7 @@ def terms(names, **kwargs):
     names : str or sequence of str
        If a single str, can specify multiple ``Term``s with string
        containing space or ',' as separator.
-    \\**kwargs : keyword arguments
+    \**kwargs : keyword arguments
        keyword arguments as for ``sympy.symbols``
 
     Returns

--- a/nipy/core/reference/coordinate_map.py
+++ b/nipy/core/reference/coordinate_map.py
@@ -2301,22 +2301,22 @@ class CoordMapMaker:
                                   inv_xform)
 
     def __call__(self, *args, **kwargs):
-        """ Create affine or non-affine coordinate map
+        r""" Create affine or non-affine coordinate map
 
         Parameters
         ----------
-        \\*args :
+        \*args :
             Arguments to ``make_affine`` or ``make_cmap`` methods. We check the
             first argument to see if it is a scalar or an affine, and pass the
-            \\*args, \\*\\*kwargs to ``make_cmap`` or ``make_affine``
+            \*args, \*\*kwargs to ``make_cmap`` or ``make_affine``
             respectively
-        \\*\\*kwargs:
+        \*\*kwargs:
             See above
 
         Returns
         -------
         cmap : ``CoordinateMap`` or ``AffineTransform``
-            Affine if the first \\*arg was an affine array, otherwise a
+            Affine if the first \*arg was an affine array, otherwise a
             Coordinate Map.
         """
         arg0 = np.asarray(args[0])

--- a/nipy/modalities/fmri/design.py
+++ b/nipy/modalities/fmri/design.py
@@ -408,7 +408,7 @@ def stack_designs(*pairs):
 
     Parameters
     ----------
-    \*pairs : sequence
+    \\*pairs : sequence
         Elements of either (np.ndarray, dict) or (np.ndarray,) or np.ndarray
 
     Returns

--- a/nipy/modalities/fmri/design.py
+++ b/nipy/modalities/fmri/design.py
@@ -402,13 +402,13 @@ def stack_contrasts(contrasts, name, keys):
 
 
 def stack_designs(*pairs):
-    """ Stack a sequence of design / contrast dictionary pairs
+    r""" Stack a sequence of design / contrast dictionary pairs
 
     Uses multiple calls to :func:`stack2designs`
 
     Parameters
     ----------
-    \\*pairs : sequence
+    \*pairs : sequence
         Elements of either (np.ndarray, dict) or (np.ndarray,) or np.ndarray
 
     Returns

--- a/nipy/modalities/fmri/utils.py
+++ b/nipy/modalities/fmri/utils.py
@@ -167,7 +167,7 @@ def interp(times, values, fill=0, name=None, **kw):
         error outside bounds
     name : None or str, optional
         Name of symbolic expression to use. If None, a default is used.
-    \*\*kw : keyword args, optional
+    \\*\\*kw : keyword args, optional
         passed to ``interp1d``
 
     Returns
@@ -229,7 +229,7 @@ def linear_interp(times, values, fill=0, name=None, **kw):
         error outside bounds
     name : None or str, optional
         Name of symbolic expression to use. If None, a default is used.
-    \*\*kw : keyword args, optional
+    \\*\\*kw : keyword args, optional
         passed to ``interp1d``
 
     Returns
@@ -466,7 +466,7 @@ class TimeConvolver:
         name : None or str, optional
             Name of the convolved function in the resulting expression.
             Defaults to one created by ``utils.interp``.
-        \*\*kwargs : keyword args, optional
+        \\*\\*kwargs : keyword args, optional
             Any other arguments to pass to the ``interp1d`` function in creating
             the numerical function for `fg`.
 
@@ -508,7 +508,7 @@ def convolve_functions(f, g, f_interval, g_interval, dt,
     name : None or str, optional
        Name of the convolved function in the resulting expression.
        Defaults to one created by ``utils.interp``.
-    \*\*kwargs : keyword args, optional
+    \\*\\*kwargs : keyword args, optional
        Any other arguments to pass to the ``interp1d`` function in creating the
        numerical function for `fg`.
 

--- a/nipy/modalities/fmri/utils.py
+++ b/nipy/modalities/fmri/utils.py
@@ -142,7 +142,7 @@ def fourier_basis(freq):
 
 
 def interp(times, values, fill=0, name=None, **kw):
-    """ Generic interpolation function of t given `times` and `values`
+    r""" Generic interpolation function of t given `times` and `values`
 
     Imterpolator such that:
 
@@ -167,7 +167,7 @@ def interp(times, values, fill=0, name=None, **kw):
         error outside bounds
     name : None or str, optional
         Name of symbolic expression to use. If None, a default is used.
-    \\*\\*kw : keyword args, optional
+    \*\*kw : keyword args, optional
         passed to ``interp1d``
 
     Returns
@@ -206,7 +206,7 @@ interp.counter = 0
 
 
 def linear_interp(times, values, fill=0, name=None, **kw):
-    """ Linear interpolation function of t given `times` and `values`
+    r""" Linear interpolation function of t given `times` and `values`
 
     Imterpolator such that:
 
@@ -229,7 +229,7 @@ def linear_interp(times, values, fill=0, name=None, **kw):
         error outside bounds
     name : None or str, optional
         Name of symbolic expression to use. If None, a default is used.
-    \\*\\*kw : keyword args, optional
+    \*\*kw : keyword args, optional
         passed to ``interp1d``
 
     Returns
@@ -455,7 +455,7 @@ class TimeConvolver:
         self._vals = _eval_for(expr, self.support, self.delta)
 
     def convolve(self, g, g_interval, name=None, **kwargs):
-        """ Convolve sympy expression `g` with this kernel
+        r""" Convolve sympy expression `g` with this kernel
 
         Parameters
         ----------
@@ -466,7 +466,7 @@ class TimeConvolver:
         name : None or str, optional
             Name of the convolved function in the resulting expression.
             Defaults to one created by ``utils.interp``.
-        \\*\\*kwargs : keyword args, optional
+        \*\*kwargs : keyword args, optional
             Any other arguments to pass to the ``interp1d`` function in creating
             the numerical function for `fg`.
 
@@ -488,7 +488,7 @@ class TimeConvolver:
 
 def convolve_functions(f, g, f_interval, g_interval, dt,
                        fill=0, name=None, **kwargs):
-    """ Expression containing numerical convolution of `fn1` with `fn2`
+    r""" Expression containing numerical convolution of `fn1` with `fn2`
 
     Parameters
     ----------
@@ -508,7 +508,7 @@ def convolve_functions(f, g, f_interval, g_interval, dt,
     name : None or str, optional
        Name of the convolved function in the resulting expression.
        Defaults to one created by ``utils.interp``.
-    \\*\\*kwargs : keyword args, optional
+    \*\*kwargs : keyword args, optional
        Any other arguments to pass to the ``interp1d`` function in creating the
        numerical function for `fg`.
 

--- a/nipy/utils/perlpie.py
+++ b/nipy/utils/perlpie.py
@@ -1,6 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""Perform a global search and replace on the current directory *recursively*.
+r"""Perform a global search and replace on the current directory *recursively*.
 
 This a small python wrapper around the `perl -p -i -e` functionality.
 I **strongly recommend** running `perlpie` on files under source
@@ -36,16 +36,16 @@ Replace all occurences of foo with bar::
 
 Replace numpy.testing with nipy's testing framework::
 
-    perlpie 'from\\s+numpy\\.testing.*' 'from nipy.testing import *'
+    perlpie 'from\s+numpy\.testing.*' 'from nipy.testing import *'
 
 Replace all @slow decorators in my code with @dec.super_slow.  Here we
 have to escape the @ symbol which has special meaning in perl::
 
-    perlpie '\\@slow' '\\@dec.super_slow'
+    perlpie '\@slow' '\@dec.super_slow'
 
 Remove all occurences of importing make_doctest_suite::
 
-    perlpie 'from\\snipy\\.utils\\.testutils.*make_doctest_suite'
+    perlpie 'from\snipy\.utils\.testutils.*make_doctest_suite'
 
 """
 
@@ -71,15 +71,15 @@ def check_deps():
 
 
 def perl_dash_pie(oldstr, newstr, dry_run=None):
-    """Use perl to replace the oldstr with the newstr.
+    r"""Use perl to replace the oldstr with the newstr.
 
     Examples
     --------
 
     # To replace all occurences of 'import numpy as N' with 'import numpy as np'
     from nipy.utils import perlpie
-    perlpie.perl_dash_pie('import\\s+numpy\\s+as\\s+N', 'import numpy as np')
-    grind | xargs perl -pi -e 's/import\\s+numpy\\s+as\\s+N/import numpy as np/g'
+    perlpie.perl_dash_pie('import\s+numpy\s+as\s+N', 'import numpy as np')
+    grind | xargs perl -pi -e 's/import\s+numpy\s+as\s+N/import numpy as np/g'
 
     """
 

--- a/nipy/utils/perlpie.py
+++ b/nipy/utils/perlpie.py
@@ -36,16 +36,16 @@ Replace all occurences of foo with bar::
 
 Replace numpy.testing with nipy's testing framework::
 
-    perlpie 'from\s+numpy\.testing.*' 'from nipy.testing import *'
+    perlpie 'from\\s+numpy\\.testing.*' 'from nipy.testing import *'
 
 Replace all @slow decorators in my code with @dec.super_slow.  Here we
 have to escape the @ symbol which has special meaning in perl::
 
-    perlpie '\@slow' '\@dec.super_slow'
+    perlpie '\\@slow' '\\@dec.super_slow'
 
 Remove all occurences of importing make_doctest_suite::
 
-    perlpie 'from\snipy\.utils\.testutils.*make_doctest_suite'
+    perlpie 'from\\snipy\\.utils\\.testutils.*make_doctest_suite'
 
 """
 
@@ -78,8 +78,8 @@ def perl_dash_pie(oldstr, newstr, dry_run=None):
 
     # To replace all occurences of 'import numpy as N' with 'import numpy as np'
     from nipy.utils import perlpie
-    perlpie.perl_dash_pie('import\s+numpy\s+as\s+N', 'import numpy as np')
-    grind | xargs perl -pi -e 's/import\s+numpy\s+as\s+N/import numpy as np/g'
+    perlpie.perl_dash_pie('import\\s+numpy\\s+as\\s+N', 'import numpy as np')
+    grind | xargs perl -pi -e 's/import\\s+numpy\\s+as\\s+N/import numpy as np/g'
 
     """
 

--- a/nipy/utils/perlpie.py
+++ b/nipy/utils/perlpie.py
@@ -78,7 +78,7 @@ def perl_dash_pie(oldstr, newstr, dry_run=None):
 
     # To replace all occurences of 'import numpy as N' with 'import numpy as np'
     from nipy.utils import perlpie
-    perlpie.perl_dash_pie('import\s+numpy\s+as\s+N', 'import numpy as np')
+    perlpie.perl_dash_pie(r'import\s+numpy\s+as\s+N', 'import numpy as np')
     grind | xargs perl -pi -e 's/import\s+numpy\s+as\s+N/import numpy as np/g'
 
     """

--- a/tools/apigen.py
+++ b/tools/apigen.py
@@ -68,9 +68,9 @@ class ApiDocWriter:
             ['\.setup$', '\._']
         '''
         if package_skip_patterns is None:
-            package_skip_patterns = ['\\.tests$']
+            package_skip_patterns = [r'\.tests$']
         if module_skip_patterns is None:
-            module_skip_patterns = ['\\.setup$', '\\._']
+            module_skip_patterns = [r'\.setup$', r'\._']
         self.package_name = package_name
         self.rst_extension = rst_extension
         self.package_skip_patterns = package_skip_patterns
@@ -272,7 +272,7 @@ class ApiDocWriter:
         return ad
 
     def _survives_exclude(self, matchstr, match_type):
-        ''' Returns True if *matchstr* does not match patterns
+        r''' Returns True if *matchstr* does not match patterns
 
         ``self.package_name`` removed from front of string if present
 
@@ -281,14 +281,14 @@ class ApiDocWriter:
         >>> dw = ApiDocWriter('sphinx')
         >>> dw._survives_exclude('sphinx.okpkg', 'package')
         True
-        >>> dw.package_skip_patterns.append('^\\.badpkg$')
+        >>> dw.package_skip_patterns.append(r'^\.badpkg$')
         >>> dw._survives_exclude('sphinx.badpkg', 'package')
         False
         >>> dw._survives_exclude('sphinx.badpkg', 'module')
         True
         >>> dw._survives_exclude('sphinx.badmod', 'module')
         True
-        >>> dw.module_skip_patterns.append('^\\.badmod$')
+        >>> dw.module_skip_patterns.append(r'^\.badmod$')
         >>> dw._survives_exclude('sphinx.badmod', 'module')
         False
         '''


### PR DESCRIPTION
Escape backslashes that should be passed through to the documentation system rather than interpreted as backslash escape sequences in the Python string.

This fixes a number of `SyntaxWarning` instances about invalid escape sequences in Python 3.12.

An alternative would be to make these docstrings raw strings (`r"""foo"""`).