### PR TITLE
Cython: declare pointers one per line

### DIFF
--- a/nipy/algorithms/statistics/_quantile.pyx
+++ b/nipy/algorithms/statistics/_quantile.pyx
@@ -48,7 +48,8 @@ def _quantile(X, double ratio, int interp=False, int axis=0):
     Y : array
       Array of quantiles
     """
-    cdef double *x, *y
+    cdef double *x
+    cdef double *y
     cdef long int size, stride
     cdef np.flatiter itX, itY
 

--- a/nipy/labs/bindings/array.pyx
+++ b/nipy/labs/bindings/array.pyx
@@ -42,7 +42,8 @@ def array_get_block( A, size_t x0, size_t x1, size_t fX=1,
                                size_t z0=0, size_t z1=0, size_t fZ=1,
                                size_t t0=0, size_t t1=0, size_t fT=1 )
     """
-    cdef fff_array *a, *b
+    cdef fff_array *a
+    cdef fff_array *b
     cdef fff_array asub
     a = fff_array_fromPyArray(A)
     asub = fff_array_get_block(a, x0, x1, fX, y0, y1, fY, z0, z1, fZ, t0, t1, fT)
@@ -57,7 +58,9 @@ def array_add(A, B):
     """
     C = A + B
     """
-    cdef fff_array *a, *b, *c
+    cdef fff_array *a
+    cdef fff_array *b
+    cdef fff_array *c
 
     a = fff_array_fromPyArray(A)
     b = fff_array_fromPyArray(B)
@@ -74,7 +77,9 @@ def array_mul(A, B):
     """
     C = A * B
     """
-    cdef fff_array *a, *b, *c
+    cdef fff_array *a
+    cdef fff_array *b
+    cdef fff_array *c
 
     a = fff_array_fromPyArray(A)
     b = fff_array_fromPyArray(B)
@@ -91,7 +96,9 @@ def array_sub(A, B):
     """
     C = A - B
     """
-    cdef fff_array *a, *b, *c
+    cdef fff_array *a
+    cdef fff_array *b
+    cdef fff_array *c
 
     a = fff_array_fromPyArray(A)
     b = fff_array_fromPyArray(B)
@@ -108,7 +115,9 @@ def array_div(A, B):
     """
     C = A / B
     """
-    cdef fff_array *a, *b, *c
+    cdef fff_array *a
+    cdef fff_array *b
+    cdef fff_array *c
 
     a = fff_array_fromPyArray(A)
     b = fff_array_fromPyArray(B)

--- a/nipy/labs/bindings/linalg.pyx
+++ b/nipy/labs/bindings/linalg.pyx
@@ -105,7 +105,8 @@ def vector_set(X, size_t i, double a):
     Set i-th element.
     vector_set(x, i, a)
     """
-    cdef fff_vector *x, *y
+    cdef fff_vector *x
+    cdef fff_vector *y
     x = fff_vector_fromPyArray(X)
     y = fff_vector_new(x.size)
     fff_vector_memcpy(y, x)
@@ -119,7 +120,8 @@ def vector_set_all(X, double a):
     Set to a constant value.
     vector_set_all(x, a)
     """
-    cdef fff_vector *x, *y
+    cdef fff_vector *x
+    cdef fff_vector *y
     x = fff_vector_fromPyArray(X)
     y = fff_vector_new(x.size)
     fff_vector_memcpy(y, x)
@@ -133,7 +135,8 @@ def vector_scale(X, double a):
     Multiply by a constant value.
     y = vector_scale(x, a)
     """
-    cdef fff_vector *x, *y
+    cdef fff_vector *x
+    cdef fff_vector *y
     x = fff_vector_fromPyArray(X)
     y = fff_vector_new(x.size)
     fff_vector_memcpy(y, x)
@@ -147,7 +150,8 @@ def vector_add_constant(X, double a):
     Add a constant value.
     y = vector_add_constant(x, a)
     """
-    cdef fff_vector *x, *y
+    cdef fff_vector *x
+    cdef fff_vector *y
     x = fff_vector_fromPyArray(X)
     y = fff_vector_new(x.size)
     fff_vector_memcpy(y, x)
@@ -161,7 +165,9 @@ def vector_add(X, Y):
     Add two vectors.
     z = vector_add(x, y)
     """
-    cdef fff_vector *x, *y, *z
+    cdef fff_vector *x
+    cdef fff_vector *y
+    cdef fff_vector *z
     x = fff_vector_fromPyArray(X)
     y = fff_vector_fromPyArray(Y)
     z = fff_vector_new(x.size)
@@ -177,7 +183,9 @@ def vector_sub(X, Y):
     Substract two vectors: x - y
     z = vector_sub(x, y)
     """
-    cdef fff_vector *x, *y, *z
+    cdef fff_vector *x
+    cdef fff_vector *y
+    cdef fff_vector *z
     x = fff_vector_fromPyArray(X)
     y = fff_vector_fromPyArray(Y)
     z = fff_vector_new(x.size)
@@ -193,7 +201,9 @@ def vector_mul(X, Y):
     Element-wise multiplication.
     z = vector_mul(x, y)
     """
-    cdef fff_vector *x, *y, *z
+    cdef fff_vector *x
+    cdef fff_vector *y
+    cdef fff_vector *z
     x = fff_vector_fromPyArray(X)
     y = fff_vector_fromPyArray(Y)
     z = fff_vector_new(x.size)
@@ -209,7 +219,9 @@ def vector_div(X, Y):
     Element-wise division.
     z = vector_div(x, y)
     """
-    cdef fff_vector *x, *y, *z
+    cdef fff_vector *x
+    cdef fff_vector *y
+    cdef fff_vector *z
     x = fff_vector_fromPyArray(X)
     y = fff_vector_fromPyArray(Y)
     z = fff_vector_new(x.size)
@@ -300,7 +312,8 @@ def matrix_transpose(A):
     Transpose a matrix.
     B = matrix_transpose(A)
     """
-    cdef fff_matrix *a, *b
+    cdef fff_matrix *a
+    cdef fff_matrix *b
     a = fff_matrix_fromPyArray(A)
     b = fff_matrix_new(a.size2, a.size1)
     fff_matrix_transpose(b, a)
@@ -312,7 +325,9 @@ def matrix_add(A, B):
     """
     C = matrix_add(A, B)
     """
-    cdef fff_matrix *a, *b, *c
+    cdef fff_matrix *a
+    cdef fff_matrix *b
+    cdef fff_matrix *c
     a = fff_matrix_fromPyArray(A)
     b = fff_matrix_fromPyArray(B)
     c = fff_matrix_new(a.size1, a.size2)
@@ -368,13 +383,16 @@ def blas_dasum(X):
     return fff_blas_dasum(x)
 
 def blas_ddot(X, Y):
-    cdef fff_vector *x, *y
+    cdef fff_vector *x
+    cdef fff_vector *y
     x = fff_vector_fromPyArray(X)
     y = fff_vector_fromPyArray(Y)
     return fff_blas_ddot(x, y)
 
 def blas_daxpy(double alpha, X, Y):
-    cdef fff_vector *x, *y, *z
+    cdef fff_vector *x
+    cdef fff_vector *y
+    cdef fff_vector *z
     x = fff_vector_fromPyArray(X)
     y = fff_vector_fromPyArray(Y)
     z = fff_vector_new(y.size)
@@ -384,7 +402,8 @@ def blas_daxpy(double alpha, X, Y):
     return Z
 
 def blas_dscal(double alpha, X):
-    cdef fff_vector *x, *y
+    cdef fff_vector *x
+    cdef fff_vector *y
     x = fff_vector_fromPyArray(X)
     y = fff_vector_new(x.size)
     fff_vector_memcpy(y, x)
@@ -403,7 +422,10 @@ def blas_dgemm(int TransA, int TransB, double alpha, A, B, double beta, C):
     beta C where op(A) = A, A^T, A^H for TransA = CblasNoTrans,
     CblasTrans, CblasConjTrans and similarly for the parameter TransB.
     """
-    cdef fff_matrix *a, *b, *c, *d
+    cdef fff_matrix *a
+    cdef fff_matrix *b
+    cdef fff_matrix *c
+    cdef fff_matrix *d
     a = fff_matrix_fromPyArray(A)
     b = fff_matrix_fromPyArray(B)
     c = fff_matrix_fromPyArray(C)
@@ -428,7 +450,10 @@ def blas_dsymm(int Side, int Uplo, double alpha, A, B, beta, C):
     when Uplo is CblasLower then the lower triangle and diagonal of A
     are used.
     """
-    cdef fff_matrix *a, *b, *c, *d
+    cdef fff_matrix *a
+    cdef fff_matrix *b
+    cdef fff_matrix *c
+    cdef fff_matrix *d
     a = fff_matrix_fromPyArray(A)
     b = fff_matrix_fromPyArray(B)
     c = fff_matrix_fromPyArray(C)
@@ -455,7 +480,9 @@ def blas_dtrmm(int Side, int Uplo, int TransA, int Diag, double alpha, A, B):
     diagonal elements of the matrix A are taken as unity and are not
     referenced.
     """
-    cdef fff_matrix *a, *b, *c
+    cdef fff_matrix *a
+    cdef fff_matrix *b
+    cdef fff_matrix *c
     a = fff_matrix_fromPyArray(A)
     b = fff_matrix_fromPyArray(B)
     c = fff_matrix_new(a.size1, a.size2)
@@ -482,7 +509,9 @@ def blas_dtrsm(int Side, int Uplo, int TransA, int Diag, double alpha, A, B):
     CblasUnit then the diagonal elements of the matrix A are taken as
     unity and are not referenced.
     """
-    cdef fff_matrix *a, *b, *c
+    cdef fff_matrix *a
+    cdef fff_matrix *b
+    cdef fff_matrix *c
     a = fff_matrix_fromPyArray(A)
     b = fff_matrix_fromPyArray(B)
     c = fff_matrix_new(a.size1, a.size2)
@@ -507,7 +536,9 @@ def blas_dsyrk(int Uplo, int Trans, double alpha, A, double beta, C):
     when Uplo is CblasLower then the lower triangle and diagonal of C
     are used.
     """
-    cdef fff_matrix *a, *c, *d
+    cdef fff_matrix *a
+    cdef fff_matrix *c
+    cdef fff_matrix *d
     a = fff_matrix_fromPyArray(A)
     c = fff_matrix_fromPyArray(C)
     d = fff_matrix_new(a.size1, a.size2)
@@ -529,7 +560,10 @@ def blas_dsyr2k(int Uplo, int Trans, double alpha, A, B, double beta, C):
     and when Uplo is CblasLower then the lower triangle and diagonal of C
     are used.
     """
-    cdef fff_matrix *a, *b, *c, *d
+    cdef fff_matrix *a
+    cdef fff_matrix *b
+    cdef fff_matrix *c
+    cdef fff_matrix *d
     a = fff_matrix_fromPyArray(A)
     b = fff_matrix_fromPyArray(B)
     c = fff_matrix_fromPyArray(C)

--- a/nipy/labs/bindings/wrapper.pyx
+++ b/nipy/labs/bindings/wrapper.pyx
@@ -62,7 +62,8 @@ def pass_vector(ndarray X):
     """
     Y = pass_vector(X)
     """
-    cdef fff_vector *x, *y
+    cdef fff_vector *x
+    cdef fff_vector *y
     x = fff_vector_fromPyArray(X)
     y = fff_vector_new(x.size)
     fff_vector_memcpy(y, x)
@@ -105,7 +106,8 @@ def pass_matrix(ndarray X):
     """
     Y = pass_matrix(X)
     """
-    cdef fff_matrix *x, *y
+    cdef fff_matrix *x
+    cdef fff_matrix *y
     x = fff_matrix_fromPyArray(X)
     y = fff_matrix_new(x.size1, x.size2)
     fff_matrix_memcpy(y, x)
@@ -117,7 +119,8 @@ def pass_array(ndarray X):
     """
     Y = pass_array(X)
     """
-    cdef fff_array *x, *y
+    cdef fff_array *x
+    cdef fff_array *y
     x = fff_array_fromPyArray(X)
     y = fff_array_new(x.datatype, x.dimX, x.dimY, x.dimZ, x.dimT)
     fff_array_copy(y, x)
@@ -129,7 +132,9 @@ def pass_vector_via_iterator(ndarray X, int axis=0, int niters=0):
     """
     Y = pass_vector_via_iterator(X, axis=0, niters=0)
     """
-    cdef fff_vector *x, *y, *z
+    cdef fff_vector *x
+    cdef fff_vector *y
+    cdef fff_vector *z
     cdef fffpy_multi_iterator* multi
 
     Xdum = X.copy() ## at least two arrays needed for multi iterator
@@ -152,7 +157,8 @@ def copy_via_iterators(ndarray Y, int axis=0):
     Copy array Y into Z via fff's PyArray_MultiIterAllButAxis C function.
     Behavior should be equivalent to Z = Y.copy().
     """
-    cdef fff_vector *y, *z
+    cdef fff_vector *y
+    cdef fff_vector *z
     cdef fffpy_multi_iterator* multi
 
     # Allocate output array
@@ -184,7 +190,8 @@ def sum_via_iterators(ndarray Y, int axis=0):
     Return the sum of input elements along the dimension specified by axis.
     Behavior should be equivalent to Z = Y.sum(axis).
     """
-    cdef fff_vector *y, *z
+    cdef fff_vector *y
+    cdef fff_vector *z
     cdef fffpy_multi_iterator* multi
 
     # Allocate output array

--- a/nipy/labs/glm/kalman.pyx
+++ b/nipy/labs/glm/kalman.pyx
@@ -84,7 +84,9 @@ def ols(ndarray Y, ndarray X, int axis=0):
 
     REFERENCE:  Roche et al, ISBI 2004.
     """
-    cdef fff_vector *y, *b, *s2
+    cdef fff_vector *y
+    cdef fff_vector *b
+    cdef fff_vector *s2
     cdef fff_matrix *x
     cdef fff_glm_KF *kfilt
     cdef size_t p
@@ -161,7 +163,11 @@ def ar1(ndarray Y, ndarray X, int niter=2, int axis=0):
     REFERENCE:
     Roche et al, MICCAI 2004.
     """
-    cdef fff_vector *y, *b, *vb, *s2, *a
+    cdef fff_vector *y
+    cdef fff_vector *b
+    cdef fff_vector *vb
+    cdef fff_vector *s2
+    cdef fff_vector *a
     cdef fff_vector Vb_flat
     cdef fff_matrix *x
     cdef fff_glm_RKF *rkfilt

--- a/nipy/labs/group/glm_twolevel.pyx
+++ b/nipy/labs/group/glm_twolevel.pyx
@@ -61,8 +61,12 @@ def em(ndarray Y, ndarray VY, ndarray X, ndarray C=None, int axis=0, int niter=D
     Keller and Roche, ISBI 2008.
     """
     cdef size_t n, p
-    cdef fff_vector *y, *vy, *b, *s2
-    cdef fff_matrix *x, *ppx
+    cdef fff_vector *y
+    cdef fff_vector *vy
+    cdef fff_vector *b
+    cdef fff_vector *s2
+    cdef fff_matrix *x
+    cdef fff_matrix *ppx
     cdef fff_glm_twolevel_EM *em
     cdef fffpy_multi_iterator* multi
 
@@ -131,7 +135,12 @@ def log_likelihood(Y, VY, X, B, S2, int axis=0):
     REFERENCE:
     Keller and Roche, ISBI 2008.
     """
-    cdef fff_vector *y, *vy, *b, *s2, *ll, *tmp
+    cdef fff_vector *y
+    cdef fff_vector *vy
+    cdef fff_vector *b
+    cdef fff_vector *s2
+    cdef fff_vector *ll
+    cdef fff_vector *tmp
     cdef fff_matrix *x
     cdef fffpy_multi_iterator* multi
 

--- a/nipy/labs/group/onesample.pyx
+++ b/nipy/labs/group/onesample.pyx
@@ -93,7 +93,10 @@ def stat(ndarray Y, id='student', double base=0.0,
   Compute a one-sample test statistic over a number of deterministic
   or random permutations.
   """
-  cdef fff_vector *y, *t, *magics, *yp
+  cdef fff_vector *y
+  cdef fff_vector *t
+  cdef fff_vector *magics
+  cdef fff_vector *yp
   cdef fff_onesample_stat* stat
   cdef fff_onesample_stat_flag flag_stat = stats[id]
   cdef unsigned int n
@@ -162,7 +165,11 @@ def stat_mfx(ndarray Y, ndarray V, id='student_mfx', double base=0.0,
   Compute a one-sample test statistic, with mixed-effect correction,
   over a number of deterministic or random permutations.
   """
-  cdef fff_vector *y, *v, *t, *magics, *yp
+  cdef fff_vector *y
+  cdef fff_vector *v
+  cdef fff_vector *t
+  cdef fff_vector *magics
+  cdef fff_vector *yp
   cdef fff_onesample_stat_mfx* stat
   cdef fff_onesample_stat_flag flag_stat = stats[id]
   cdef int n
@@ -233,7 +240,10 @@ def pdf_fit_mfx(ndarray Y, ndarray V, int axis=0, int niter=5, int constraint=0,
 
   Comments to follow.
   """
-  cdef fff_vector *y, *v, *w, *z
+  cdef fff_vector *y
+  cdef fff_vector *v
+  cdef fff_vector *w
+  cdef fff_vector *z
   cdef fff_onesample_stat_mfx* stat
   cdef fffpy_multi_iterator* multi
   cdef int n = Y.shape[axis]
@@ -277,7 +287,10 @@ def pdf_fit_gmfx(ndarray Y, ndarray V, int axis=0, int niter=5, int constraint=0
 
   Comments to follow.
   """
-  cdef fff_vector *y, *v, *mu, *s2
+  cdef fff_vector *y
+  cdef fff_vector *v
+  cdef fff_vector *mu
+  cdef fff_vector *s2
   cdef fff_onesample_stat_mfx* stat
   cdef fffpy_multi_iterator* multi
   cdef int n = Y.shape[axis]

--- a/nipy/labs/group/twosample.pyx
+++ b/nipy/labs/group/twosample.pyx
@@ -70,8 +70,13 @@ def stat(ndarray Y1, ndarray Y2, id='student', int axis=0, ndarray Magics=None):
   Compute a two-sample test statistic (Y1>Y2) over a number of
   deterministic or random permutations.
   """
-  cdef fff_vector *y1, *y2, *t, *yp, *magics
-  cdef fff_array *idx1, *idx2
+  cdef fff_vector *y1
+  cdef fff_vector *y2
+  cdef fff_vector *t
+  cdef fff_vector *yp
+  cdef fff_vector *magics
+  cdef fff_array *idx1
+  cdef fff_array *idx2
   cdef unsigned int n, n1, n2, nex
   cdef unsigned long int simu, nsimu, idx
   cdef fff_twosample_stat* stat
@@ -155,8 +160,16 @@ def stat_mfx(ndarray Y1, ndarray V1, ndarray Y2, ndarray V2,
   Compute a two-sample test statistic (Y1>Y2) over a number of
   deterministic or random permutations.
   """
-  cdef fff_vector *y1, *y2, *v1, *v2, *t, *yp, *vp, *magics
-  cdef fff_array *idx1, *idx2
+  cdef fff_vector *y1
+  cdef fff_vector *y2
+  cdef fff_vector *v1
+  cdef fff_vector *v2
+  cdef fff_vector *t
+  cdef fff_vector *yp
+  cdef fff_vector *vp
+  cdef fff_vector *magics
+  cdef fff_array *idx1
+  cdef fff_array *idx2
   cdef unsigned int n, n1, n2, nex
   cdef unsigned long int simu, nsimu, idx
   cdef fff_twosample_stat_mfx* stat

--- a/nipy/labs/utils/routines.pyx
+++ b/nipy/labs/utils/routines.pyx
@@ -53,7 +53,8 @@ def quantile(X, double ratio, int interp=False, int axis=0):
 
     Partial sorting algorithm, very fast!!!
     """
-    cdef fff_vector *x, *y
+    cdef fff_vector *x
+    cdef fff_vector *y
     cdef fffpy_multi_iterator* multi
 
     # Allocate output array Y
@@ -98,7 +99,11 @@ def mahalanobis(X, VX):
     axis == 0 assumed. If X is shaped (d,K), VX must be shaped
     (d,d,K).
     """
-    cdef fff_vector *x, *vx, *x_tmp, *vx_tmp, *d2
+    cdef fff_vector *x
+    cdef fff_vector *vx
+    cdef fff_vector *x_tmp
+    cdef fff_vector *vx_tmp
+    cdef fff_vector *d2
     cdef fff_matrix Sx
     cdef fff_matrix *Sx_tmp
     cdef fffpy_multi_iterator* multi
@@ -163,10 +168,16 @@ def svd(X):
     """
     cdef int axis=0
     cdef int m, n, dmin, dmax, lwork, liwork, info
-    cdef fff_vector *work, *x_flat, *x_flat_tmp, *s, *s_tmp
+    cdef fff_vector *work
+    cdef fff_vector *x_flat
+    cdef fff_vector *x_flat_tmp
+    cdef fff_vector *s
+    cdef fff_vector *s_tmp
     cdef fff_matrix x
     cdef fff_array *iwork
-    cdef fff_matrix *Aux, *U, *Vt
+    cdef fff_matrix *Aux
+    cdef fff_matrix *U
+    cdef fff_matrix *Vt
     cdef fffpy_multi_iterator* multi
 
     # Shape of matrices
@@ -235,7 +246,8 @@ def permutations(unsigned int n, unsigned int m=1, unsigned long magic=0):
     P = permutations(n, m=1, magic=0).
     Generate m permutations from [0..n[.
     """
-    cdef fff_array *p, *pi
+    cdef fff_array *p
+    cdef fff_array *pi
     cdef fff_array pi_view
     cdef unsigned int i
     p = fff_array_new2d(FFF_UINT, n, m)


### PR DESCRIPTION
None of these declarations was incorrect, but Cython now warns about them. The developers are worried that people will write “`cdef int* a, b`” and think that “`b`” is an “`int*`” rather than an “`int`”. Reducing the number of warnings from Cython makes it easier to notice warnings that might represent real problems.

See also https://groups.google.com/g/cython-users/c/MA8I1wmoT0Q for discussion.