### PR TITLE
Improve const-correctness in C code

### DIFF
--- a/lib/fff_python_wrapper/fffpy.c
+++ b/lib/fff_python_wrapper/fffpy.c
@@ -203,7 +203,7 @@ fff_matrix* fff_matrix_fromPyArray(const PyArrayObject* x)
     y->size1 = (size_t) PyArray_DIM(x,0);
     y->size2 = (size_t) PyArray_DIM(x,1);
     y->tda = y->size2;
-    y->data = (double*) PyArray_DATA(x);
+    y->data = PyArray_DATA(x);
     y->owner = 0;
   }
   /* Otherwise, output a owner (contiguous) matrix with copied
@@ -427,7 +427,7 @@ fff_array* fff_array_fromPyArray(const PyArrayObject* x)
   /* Create array (not owner) */
   y = (fff_array*)malloc(sizeof(fff_array));
   *y = fff_array_view(datatype,
-		      (void*) PyArray_DATA(x),
+		      PyArray_DATA(x),
 		      dimX, dimY, dimZ, dimT,
 		      offX, offY, offZ, offT);
 

--- a/nipy/algorithms/registration/cubic_spline.c
+++ b/nipy/algorithms/registration/cubic_spline.c
@@ -224,11 +224,14 @@ void cubic_spline_transform(PyArrayObject* res, const PyArrayObject* src)
 
 double cubic_spline_sample1d (double x, const PyArrayObject* Coef, int mode)
 {
-
-  unsigned int ddim = PyArray_DIM(Coef, 0) - 1;
-  unsigned int offset = PyArray_STRIDE(Coef, 0)/sizeof(double);
-  double *coef = PyArray_DATA(Coef);
-  double *buf;
+  /* Since PyArray_DATA(), PyArray_DIMS(), and PyArray_STRIDE() are simple
+   * accessors, it is OK to cast away const as long as we treat any returned
+   * pointers as const.
+   */
+  unsigned int ddim = PyArray_DIM((PyArrayObject*) Coef, 0) - 1;
+  unsigned int offset = PyArray_STRIDE((PyArrayObject*) Coef, 0)/sizeof(double);
+  const double *coef = PyArray_DATA((PyArrayObject*) Coef);
+  const double *buf;
   int nx, px, xx;
   double s;
   double bspx[4];
@@ -273,13 +276,16 @@ double cubic_spline_sample1d (double x, const PyArrayObject* Coef, int mode)
 double cubic_spline_sample2d (double x, double y, const PyArrayObject* Coef,
 			      int mode_x, int mode_y)
 {
-
-  unsigned int ddimX = PyArray_DIM(Coef, 0) - 1;
-  unsigned int ddimY = PyArray_DIM(Coef, 1) - 1;
-  unsigned int offX = PyArray_STRIDE(Coef, 0)/sizeof(double);
-  unsigned int offY = PyArray_STRIDE(Coef, 1)/sizeof(double);
-  double *coef = PyArray_DATA(Coef);
-  double *buf;
+  /* Since PyArray_DATA(), PyArray_DIMS(), and PyArray_STRIDE() are simple
+   * accessors, it is OK to cast away const as long as we treat any returned
+   * pointers as const.
+   */
+  unsigned int ddimX = PyArray_DIM((PyArrayObject*) Coef, 0) - 1;
+  unsigned int ddimY = PyArray_DIM((PyArrayObject*) Coef, 1) - 1;
+  unsigned int offX = PyArray_STRIDE((PyArrayObject*) Coef, 0)/sizeof(double);
+  unsigned int offY = PyArray_STRIDE((PyArrayObject*) Coef, 1)/sizeof(double);
+  const double *coef = PyArray_DATA((PyArrayObject*) Coef);
+  const double *buf;
   int nx, ny, px, py, xx, yy;
   double s, aux;
   double bspx[4], bspy[4];
@@ -345,14 +351,18 @@ double cubic_spline_sample2d (double x, double y, const PyArrayObject* Coef,
 double cubic_spline_sample3d (double x, double y, double z, const PyArrayObject* Coef,
 			      int mode_x, int mode_y, int mode_z)
 {
-  unsigned int ddimX = PyArray_DIM(Coef, 0) - 1;
-  unsigned int ddimY = PyArray_DIM(Coef, 1) - 1;
-  unsigned int ddimZ = PyArray_DIM(Coef, 2) - 1;
-  unsigned int offX = PyArray_STRIDE(Coef, 0)/sizeof(double);
-  unsigned int offY = PyArray_STRIDE(Coef, 1)/sizeof(double);
-  unsigned int offZ = PyArray_STRIDE(Coef, 2)/sizeof(double);
-  double *coef = PyArray_DATA(Coef);
-  double *buf;
+  /* Since PyArray_DATA(), PyArray_DIMS(), and PyArray_STRIDE() are simple
+   * accessors, it is OK to cast away const as long as we treat any returned
+   * pointers as const.
+   */
+  unsigned int ddimX = PyArray_DIM((PyArrayObject*) Coef, 0) - 1;
+  unsigned int ddimY = PyArray_DIM((PyArrayObject*) Coef, 1) - 1;
+  unsigned int ddimZ = PyArray_DIM((PyArrayObject*) Coef, 2) - 1;
+  unsigned int offX = PyArray_STRIDE((PyArrayObject*) Coef, 0)/sizeof(double);
+  unsigned int offY = PyArray_STRIDE((PyArrayObject*) Coef, 1)/sizeof(double);
+  unsigned int offZ = PyArray_STRIDE((PyArrayObject*) Coef, 2)/sizeof(double);
+  const double *coef = PyArray_DATA((PyArrayObject*) Coef);
+  const double *buf;
   int nx, ny, nz, px, py, pz;
   int xx, yy, zz;
   double s, aux, aux2;
@@ -438,16 +448,20 @@ double cubic_spline_sample3d (double x, double y, double z, const PyArrayObject*
 double cubic_spline_sample4d (double x, double y, double z, double t, const PyArrayObject* Coef,
 			      int mode_x, int mode_y, int mode_z, int mode_t)
 {
-  unsigned int ddimX = PyArray_DIM(Coef, 0) - 1;
-  unsigned int ddimY = PyArray_DIM(Coef, 1) - 1;
-  unsigned int ddimZ = PyArray_DIM(Coef, 2) - 1;
-  unsigned int ddimT = PyArray_DIM(Coef, 3) - 1;
-  unsigned int offX = PyArray_STRIDE(Coef, 0)/sizeof(double);
-  unsigned int offY = PyArray_STRIDE(Coef, 1)/sizeof(double);
-  unsigned int offZ = PyArray_STRIDE(Coef, 2)/sizeof(double);
-  unsigned int offT = PyArray_STRIDE(Coef, 3)/sizeof(double);
-  double *coef = PyArray_DATA(Coef);
-  double *buf;
+  /* Since PyArray_DATA(), PyArray_DIMS(), and PyArray_STRIDE() are simple
+   * accessors, it is OK to cast away const as long as we treat any returned
+   * pointers as const.
+   */
+  unsigned int ddimX = PyArray_DIM((PyArrayObject*) Coef, 0) - 1;
+  unsigned int ddimY = PyArray_DIM((PyArrayObject*) Coef, 1) - 1;
+  unsigned int ddimZ = PyArray_DIM((PyArrayObject*) Coef, 2) - 1;
+  unsigned int ddimT = PyArray_DIM((PyArrayObject*) Coef, 3) - 1;
+  unsigned int offX = PyArray_STRIDE((PyArrayObject*) Coef, 0)/sizeof(double);
+  unsigned int offY = PyArray_STRIDE((PyArrayObject*) Coef, 1)/sizeof(double);
+  unsigned int offZ = PyArray_STRIDE((PyArrayObject*) Coef, 2)/sizeof(double);
+  unsigned int offT = PyArray_STRIDE((PyArrayObject*) Coef, 3)/sizeof(double);
+  const double *coef = PyArray_DATA((PyArrayObject*) Coef);
+  const double *buf;
   int nx, ny, nz, nt, px, py, pz, pt;
   int xx, yy, zz, tt;
   double s, aux, aux2, aux3;

--- a/nipy/algorithms/registration/joint_histogram.c
+++ b/nipy/algorithms/registration/joint_histogram.c
@@ -73,7 +73,7 @@ int joint_histogram(PyArrayObject* JH,
 		    const PyArrayObject* Tvox,
 		    long interp)
 {
-  const signed short* J=(signed short*)PyArray_DATA(imJ_padded);
+  const signed short* J=PyArray_DATA(imJ_padded);
   size_t dimJX=PyArray_DIMS(imJ_padded)[0]-2;
   size_t dimJY=PyArray_DIMS(imJ_padded)[1]-2;
   size_t dimJZ=PyArray_DIMS(imJ_padded)[2]-2;
@@ -92,9 +92,9 @@ int joint_histogram(PyArrayObject* JH,
   double wx, wy, wz, wxwy, wxwz, wywz;
   double W0, W2, W3, W4;
   int nn, nx, ny, nz;
-  double *H = (double*)PyArray_DATA(JH);
+  double *H = PyArray_DATA(JH);
   double Tx, Ty, Tz;
-  double *tvox = (double*)PyArray_DATA(Tvox);
+  double *tvox = PyArray_DATA(Tvox);
   void (*interpolate)(unsigned int, double*, unsigned int, const signed short*, const double*, int, void*);
   void* interp_params = NULL;
   prng_state rng;
@@ -348,7 +348,7 @@ int L1_moments(double* n_, double* median_, double* dev_,
   }
 
   /* Initialize */
-  h = (const double*)PyArray_DATA(H);
+  h = PyArray_DATA(H);
   size = PyArray_DIM(H, 0);
   offset = PyArray_STRIDE(H, 0)/sizeof(double);
 

--- a/nipy/algorithms/registration/joint_histogram.c
+++ b/nipy/algorithms/registration/joint_histogram.c
@@ -73,19 +73,23 @@ int joint_histogram(PyArrayObject* JH,
 		    const PyArrayObject* Tvox,
 		    long interp)
 {
-  const signed short* J=PyArray_DATA(imJ_padded);
-  size_t dimJX=PyArray_DIMS(imJ_padded)[0]-2;
-  size_t dimJY=PyArray_DIMS(imJ_padded)[1]-2;
-  size_t dimJZ=PyArray_DIMS(imJ_padded)[2]-2;
+  /* Since PyArray_DATA() and PyArray_DIMS() are simple accessors, it is OK to
+   * cast away const as long as we treat the results as const.
+   */
+  const signed short* J=PyArray_DATA((PyArrayObject*) imJ_padded);
+  const npy_intp* dimJ = PyArray_DIMS((PyArrayObject*) imJ_padded);
+  size_t dimJX=dimJ[0]-2;
+  size_t dimJY=dimJ[1]-2;
+  size_t dimJZ=dimJ[2]-2;
   signed short Jnn[8];
   double W[8];
   signed short *bufI, *bufJnn;
   double *bufW;
   signed short i, j;
   size_t off;
-  size_t u2 = PyArray_DIMS(imJ_padded)[2];
+  size_t u2 = dimJ[2];
   size_t u3 = u2+1;
-  size_t u4 = PyArray_DIMS(imJ_padded)[1]*u2;
+  size_t u4 = dimJ[1]*u2;
   size_t u5 = u4+1;
   size_t u6 = u4+u2;
   size_t u7 = u6+1;
@@ -94,7 +98,7 @@ int joint_histogram(PyArrayObject* JH,
   int nn, nx, ny, nz;
   double *H = PyArray_DATA(JH);
   double Tx, Ty, Tz;
-  double *tvox = PyArray_DATA(Tvox);
+  const double *tvox = PyArray_DATA((PyArrayObject*) Tvox);
   void (*interpolate)(unsigned int, double*, unsigned int, const signed short*, const double*, int, void*);
   void* interp_params = NULL;
   prng_state rng;
@@ -348,9 +352,14 @@ int L1_moments(double* n_, double* median_, double* dev_,
   }
 
   /* Initialize */
-  h = PyArray_DATA(H);
-  size = PyArray_DIM(H, 0);
-  offset = PyArray_STRIDE(H, 0)/sizeof(double);
+
+  /* Since PyArray_DATA(), PyArray_DIMS(), and PyArray_STRIDE() are simple
+   * accessors, it is OK to cast away const as long as we treat the results as
+   * const (for those accessors returning pointer types).
+   */
+  h = PyArray_DATA((PyArrayObject*) H);
+  size = PyArray_DIM((PyArrayObject*) H, 0);
+  offset = PyArray_STRIDE((PyArrayObject*) H, 0)/sizeof(double);
 
   n = median = dev = 0;
   cpdf = 0;

--- a/nipy/algorithms/registration/polyaffine.c
+++ b/nipy/algorithms/registration/polyaffine.c
@@ -6,7 +6,7 @@
 #define TINY 1e-200
 
 
-static double _gaussian(double* xyz, double* center, double* sigma)
+static double _gaussian(const double* xyz, const double* center, const double* sigma)
 {
   double aux, d2 = 0.0;
   int i;
@@ -64,14 +64,19 @@ void apply_polyaffine(PyArrayObject* XYZ,
 
   PyArrayIterObject *iter_xyz, *iter_centers, *iter_affines;
   int axis = 1;
-  double *xyz, *center, *affine, *sigma;
+  double *xyz, *center, *affine;
+  const double* sigma;
   double w, W;
   double mat[12], t_xyz[3];
   size_t bytes_mat = 12*sizeof(double);
   size_t bytes_xyz = 3*sizeof(double);
 
   /* Initialize arrays and iterators */
-  sigma = PyArray_DATA(Sigma);
+
+  /* Since PyArray_DATA() is a simple accessor, it is OK to cast away const as
+   * long as we treat the result as const.
+   */
+  sigma = PyArray_DATA((PyArrayObject*) Sigma);
   iter_xyz = (PyArrayIterObject*)PyArray_IterAllButAxis((PyObject*)XYZ, &axis);
   iter_centers = (PyArrayIterObject*)PyArray_IterAllButAxis((PyObject*)Centers, &axis);
   iter_affines = (PyArrayIterObject*)PyArray_IterAllButAxis((PyObject*)Affines, &axis);

--- a/nipy/algorithms/segmentation/mrf.c
+++ b/nipy/algorithms/segmentation/mrf.c
@@ -85,12 +85,16 @@ static void _ngb_integrate(double* res,
 {
   npy_intp xn, yn, zn, pos, ngb_idx, k, kk;
   const int* buf_ngb;
-  const double* ppm_data = PyArray_DATA(ppm);
+  /* Since PyArray_DATA() and PyArray_DIMS() are simple accessors, it is OK to
+   * cast away const as long as we treat the results as const.
+   */
+  const double* ppm_data = PyArray_DATA((PyArrayObject*) ppm);
+  const npy_intp* dim_ppm = PyArray_DIMS((PyArrayObject*) ppm);
   double *buf, *buf_ppm, *q, *buf_U;
-  npy_intp K = PyArray_DIMS(ppm)[3];
-  npy_intp u2 = PyArray_DIMS(ppm)[2]*K;
-  npy_intp u1 = PyArray_DIMS(ppm)[1]*u2;
-  npy_intp posmax = PyArray_DIMS(ppm)[0]*u1 - K;
+  npy_intp K = dim_ppm[3];
+  npy_intp u2 = dim_ppm[2]*K;
+  npy_intp u1 = dim_ppm[1]*u2;
+  npy_intp posmax = dim_ppm[0]*u1 - K;
 
   /*  Re-initialize output array */
   memset((void*)res, 0, K*sizeof(double));
@@ -134,8 +138,11 @@ void ve_step(PyArrayObject* ppm,
   npy_intp K = PyArray_DIMS(ppm)[3];
   npy_intp u2 = PyArray_DIMS(ppm)[2]*K;
   npy_intp u1 = PyArray_DIMS(ppm)[1]*u2;
-  const double* ref_data = PyArray_DATA(ref);
-  const double* U_data = PyArray_DATA(U);
+  /* Since PyArray_DATA() is a simple accessor, it is OK to cast away const as
+   * long as we treat the result as const.
+   */
+  const double* ref_data = PyArray_DATA((PyArrayObject*) ref);
+  const double* U_data = PyArray_DATA((PyArrayObject*) U);
   npy_intp* xyz;
   int* ngb;
 
@@ -208,15 +215,21 @@ PyArrayObject* make_edges(const PyArrayObject* idx,
 			  int ngb_size)
 {
   int* ngb = _select_neighborhood_system(ngb_size);
-  PyArrayIterObject* iter = (PyArrayIterObject*)PyArray_IterNew((PyObject*)idx);
   int* buf_ngb;
   npy_intp xi, yi, zi, xj, yj, zj;
-  npy_intp u2 = PyArray_DIMS(idx)[2];
-  npy_intp u1 = PyArray_DIMS(idx)[1]*u2;
-  npy_intp u0 = PyArray_DIMS(idx)[0]*u1;
+  /* Since PyArray_DIMS() is a simple accessor, it is OK to cast away const as
+   * long as we treat the result as const. Similarly, we can convert idx to a
+   * non-const PyObject for iteration purposes as long as we treat any pointer
+   * values obtained via the iterator as const.
+   */
+  PyArrayIterObject* iter = (PyArrayIterObject*)PyArray_IterNew((PyObject*)idx);
+  const npy_intp* dim_idx = PyArray_DIMS((PyArrayObject*) idx);
+  npy_intp u2 = dim_idx[2];
+  npy_intp u1 = dim_idx[1]*u2;
+  npy_intp u0 = dim_idx[0]*u1;
   npy_intp mask_size = 0, n_edges = 0;
   npy_intp idx_i;
-  npy_intp *buf_idx;
+  const npy_intp* buf_idx;
   npy_intp *edges_data, *buf_edges;
   npy_intp ngb_idx;
   npy_intp pos;
@@ -225,7 +238,7 @@ PyArrayObject* make_edges(const PyArrayObject* idx,
 
   /* First loop over the input array to determine the mask size */
   while(iter->index < iter->size) {
-    buf_idx = (npy_intp*)PyArray_ITER_DATA(iter);
+    buf_idx = PyArray_ITER_DATA(iter);
     if (*buf_idx >= 0)
       mask_size ++;
     PyArray_ITER_NEXT(iter);
@@ -244,7 +257,7 @@ PyArrayObject* make_edges(const PyArrayObject* idx,
     xi = iter->coordinates[0];
     yi = iter->coordinates[1];
     zi = iter->coordinates[2];
-    buf_idx = (npy_intp*)PyArray_ITER_DATA(iter);
+    buf_idx = PyArray_ITER_DATA(iter);
     idx_i = *buf_idx;
 
     /* Loop over neighbors if current point is within the mask */
@@ -261,7 +274,10 @@ PyArrayObject* make_edges(const PyArrayObject* idx,
 	/* Store edge if neighbor is within the mask */
 	if ((pos < 0) || (pos >= u0))
 	  continue;
-	buf_idx = PyArray_DATA(idx) + pos;
+	/* Since PyArray_DATA() is a simple accessor, it is OK to cast away
+	 * const as long as we treat the result as const.
+         */
+	buf_idx = PyArray_DATA((PyArrayObject*) idx) + pos;
 	if (*buf_idx < 0)
 	  continue;
 	buf_edges[0] = idx_i;
@@ -314,8 +330,11 @@ double interaction_energy(PyArrayObject* ppm,
   npy_intp K = PyArray_DIMS(ppm)[3];
   npy_intp u2 = PyArray_DIMS(ppm)[2]*K;
   npy_intp u1 = PyArray_DIMS(ppm)[1]*u2;
-  npy_intp* xyz;
-  const double* U_data = PyArray_DATA(U);
+  const npy_intp* xyz;
+  /* Since PyArray_DATA() is a simple accessor, it is OK to cast away const as
+   * long as we treat the result as const.
+   */
+  const double* U_data = PyArray_DATA((PyArrayObject*) U);
   int* ngb;
 
   /* Neighborhood system */
@@ -328,6 +347,10 @@ double interaction_energy(PyArrayObject* ppm,
   p = (double*)calloc(K, sizeof(double));
 
   /* Loop over points */
+
+  /* We can convert idx to a non-const PyObject for iteration purposes as long
+   * as we treat any pointer values obtained via the iterator as const.
+   */
   iter = (PyArrayIterObject*)PyArray_IterAllButAxis((PyObject*)XYZ, &axis);
   while(iter->index < iter->size) {
 

--- a/nipy/algorithms/segmentation/mrf.c
+++ b/nipy/algorithms/segmentation/mrf.c
@@ -85,7 +85,7 @@ static void _ngb_integrate(double* res,
 {
   npy_intp xn, yn, zn, pos, ngb_idx, k, kk;
   const int* buf_ngb;
-  const double* ppm_data = (double*)PyArray_DATA(ppm);
+  const double* ppm_data = PyArray_DATA(ppm);
   double *buf, *buf_ppm, *q, *buf_U;
   npy_intp K = PyArray_DIMS(ppm)[3];
   npy_intp u2 = PyArray_DIMS(ppm)[2]*K;
@@ -134,8 +134,8 @@ void ve_step(PyArrayObject* ppm,
   npy_intp K = PyArray_DIMS(ppm)[3];
   npy_intp u2 = PyArray_DIMS(ppm)[2]*K;
   npy_intp u1 = PyArray_DIMS(ppm)[1]*u2;
-  const double* ref_data = (double*)PyArray_DATA(ref);
-  const double* U_data = (double*)PyArray_DATA(U);
+  const double* ref_data = PyArray_DATA(ref);
+  const double* U_data = PyArray_DATA(U);
   npy_intp* xyz;
   int* ngb;
 
@@ -143,7 +143,7 @@ void ve_step(PyArrayObject* ppm,
   ngb = _select_neighborhood_system(ngb_size);
 
   /* Pointer to the data array */
-  ppm_data = (double*)PyArray_DATA(ppm);
+  ppm_data = PyArray_DATA(ppm);
 
   /* Allocate auxiliary vectors */
   p = (double*)calloc(K, sizeof(double));
@@ -261,7 +261,7 @@ PyArrayObject* make_edges(const PyArrayObject* idx,
 	/* Store edge if neighbor is within the mask */
 	if ((pos < 0) || (pos >= u0))
 	  continue;
-	buf_idx = (npy_intp*)PyArray_DATA(idx) + pos;
+	buf_idx = PyArray_DATA(idx) + pos;
 	if (*buf_idx < 0)
 	  continue;
 	buf_edges[0] = idx_i;
@@ -315,14 +315,14 @@ double interaction_energy(PyArrayObject* ppm,
   npy_intp u2 = PyArray_DIMS(ppm)[2]*K;
   npy_intp u1 = PyArray_DIMS(ppm)[1]*u2;
   npy_intp* xyz;
-  const double* U_data = (double*)PyArray_DATA(U);
+  const double* U_data = PyArray_DATA(U);
   int* ngb;
 
   /* Neighborhood system */
   ngb = _select_neighborhood_system(ngb_size);
 
   /* Pointer to ppm array */
-  ppm_data = (double*)PyArray_DATA(ppm);
+  ppm_data = PyArray_DATA(ppm);
 
   /* Allocate auxiliary vector */
   p = (double*)calloc(K, sizeof(double));


### PR DESCRIPTION
The commit “Do not cast the result of PyArray_DATA()” is in this PR because it touches most of the same lines that needed to be touched to fix const-related warnings.

I’d like to suggest that a broader change to stop explicitly casting `void *` return values could make sense; I claim that they add clutter and repetition but don’t reduce errors. They are not required because `void *` happily converts implicitly to any data pointer type (in C, not C++). Such a change would affect at least `malloc()`, `calloc()`, `realloc()`, and `PyArray_ITER_DATA()`. However, I don’t want to get that tangled up with the const-correctness changes, especially if it’s not desired.