### PR TITLE
MNT: apply Repo-Review suggestions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,8 @@ repos:
         files: \.(md|rst|toml|yml|yaml)
         args: [--prose-wrap=preserve]
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 6fcbf19c7cf351a8dc3517a0fed3ebfa05610de2 # frozen: v0.0.290
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 7bcc70ca475b87e0fdee2511300c74b25babe0b3 # frozen: v0.1.9
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/examples/labs/need_data/demo_roi.py
+++ b/examples/labs/need_data/demo_roi.py
@@ -109,6 +109,6 @@ wim5 = roi.to_image()
 roi_path_5 = path.join(write_dir, "roi_some_blobs.nii")
 save(wim5, roi_path_5)
 
-print("Wrote ROI mask images in {}, \n {} \n {} \n and {}".format(roi_path_2, roi_path_3, roi_path_4, roi_path_5))
+print(f"Wrote ROI mask images in {roi_path_2}, \n {roi_path_3} \n {roi_path_4} \n and {roi_path_5}")
 
 plt.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,8 @@ nipy_diagnose = 'nipy.cli.diagnose:main'
 
 [tool.ruff]
 line-length = 88
+
+[tool.ruff.lint]
 select = [
     'I',
     'UP',


### PR DESCRIPTION
Apply some [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=nipy%2Fnipy&branch=main) suggestions.

I went for the low-hanging fruits, other changes are more invasive and deserve a PR of their own, such as using a formatter like ruff of black.

### Fixed issues

* [PC190](https://learn.scientific-python.org/development/guides/style#PC190): Uses Ruff
  Use `https://github.com/astral-sh/ruff-pre-commit` instead of `https://github.com/charliermarsh/ruff-pre-commit` in `.pre-commit-config.yaml`
* RF202: Use (new) lint config section
  `select` should be set as `lint.select` instead
* VPP001: Validate pyproject.toml
  Invalid pyproject.toml! Error: `project` must not contain {'python-requires'} properties

Also, update ruff to a decently recent version.

### Issues ignored

I have left this issue for a later PR, as it requires extensive changes:
* [RF101](https://learn.scientific-python.org/development/guides/style#RF101): Bugbear must be selected
  Must select the flake8-bugbear B checks. Recommended:
  ```toml
  [tool.ruff.lint]
  extend-select = [
    "B",  # flake8-bugbear
  ]
  ```