### PR TITLE
DOC: Fix activation map tutorial

### DIFF
--- a/doc/labs/viz.rst
+++ b/doc/labs/viz.rst
@@ -37,6 +37,7 @@ An example
     # Color an asymmetric rectangle around Broca area:
     x, y, z = -52, 10, 22
     x_map, y_map, z_map = coord_transform(x, y, z, mni_sform_inv)
+    x_map, y_map, z_map = int(x_map), int(y_map), int(z_map)
     map = np.zeros((182, 218, 182))
     map[x_map-30:x_map+30, y_map-3:y_map+3, z_map-10:z_map+10] = 1
 

--- a/doc/labs/viz.rst
+++ b/doc/labs/viz.rst
@@ -36,8 +36,7 @@ An example
     mni_sform_inv = np.linalg.inv(mni_sform)
     # Color an asymmetric rectangle around Broca area:
     x, y, z = -52, 10, 22
-    x_map, y_map, z_map = coord_transform(x, y, z, mni_sform_inv)
-    x_map, y_map, z_map = int(x_map), int(y_map), int(z_map)
+    x_map, y_map, z_map = [int(coord) for coord in coord_transform(x, y, z, mni_sform_inv)]
     map = np.zeros((182, 218, 182))
     map[x_map-30:x_map+30, y_map-3:y_map+3, z_map-10:z_map+10] = 1
 


### PR DESCRIPTION
Currently the documentation for [how to plot activation maps](https://nipy.org/nipy/labs/viz.html) throws an error when run on a clean environment:
```
TypeError: slice indices must be integers or None or have an __index__ method
```

The issue is these lines
```py
x_map, y_map, z_map = coord_transform(x, y, z, mni_sform_inv)
map = np.zeros((182, 218, 182))
map[x_map-30:x_map+30, y_map-3:y_map+3, z_map-10:z_map+10] = 1
```
`x_map` is returned as a 0 dimensional `np.array` which can't be used for indexing

The current fix is a bit of a band-aid. Would it be better to modify `coord_transform()` so that it actually returns integers?