### PR TITLE
adjust coordinate_map.py and tests with sympy 1.13

### DIFF
--- a/nipy/core/reference/coordinate_map.py
+++ b/nipy/core/reference/coordinate_map.py
@@ -558,10 +558,11 @@ class AffineTransform:
                              'affine matrix shape')
         # Test that it is actually an affine mapping in homogeneous
         # form
-        bottom_row = np.array([0]*self.ndims[0] + [1])
+        bottom_row = np.array([0]*self.ndims[0] + [1.], dtype=dtype)
         if not np.all(affine[-1] == bottom_row):
             raise ValueError('the homogeneous transform should have bottom=' + \
-                             f'row {repr(bottom_row)}')
+                             f'row {repr(bottom_row)}' + ' but it has bottom=' \
+                             + f'row {repr(affine[-1])}')
         self.affine = affine
 
     ###################################################################

--- a/nipy/core/reference/tests/test_coordinate_map.py
+++ b/nipy/core/reference/tests/test_coordinate_map.py
@@ -956,8 +956,8 @@ def test_dtype_cmap_inverses():
     # Check that we can make functional inverses of AffineTransforms, and
     # CoordinateMap versions of AffineTransforms
     arr_p1 = np.eye(4)[:, [0, 2, 1, 3]]
-    in_list = [0, 1, 2]
-    out_list = [0, 2, 1]
+    in_list = [0, 1., 2.]
+    out_list = [0, 2., 1.]
     for dt in _SYMPY_SAFE_DTYPES:
         in_cs = CoordinateSystem('ijk', coord_dtype=dt)
         out_cs = CoordinateSystem('xyz', coord_dtype=dt)
@@ -975,7 +975,7 @@ def test_dtype_cmap_inverses():
         except:
             1/0
         res = r_cmap(out_coord)
-        assert_array_equal(res, coord)
+        assert_array_equal(res, np.asarray(coord, dtype=exp_i_dt))
         assert res.dtype == exp_i_dt
         # Default behavior is preserve_type=False
         r_cmap = cmap.inverse(preserve_dtype=False)
@@ -991,7 +991,7 @@ def test_dtype_cmap_inverses():
         cm_cmap = _as_coordinate_map(cmap)
         assert_array_equal(cm_cmap(coord), out_list)
         rcm_cmap = cm_cmap.inverse()
-        assert_array_equal(rcm_cmap(coord), out_list)
+        assert_array_equal(rcm_cmap(coord), np.asarray(out_list, dtype=dt))
         res = rcm_cmap(out_coord)
         assert_array_equal(res, coord)
         assert res.dtype == dt


### PR DESCRIPTION
Since version 1.13, SymPy makes a hard distinction between integers and floating point numbers.  This causes a couple of tests to fail, with the most relevant part of the error showing:

	self = AffineTransform(
	   function_domain=CoordinateSystem(coord_names=('x', 'y', 'z'), name='', coord_dtype=object),
	   fun...ne=array([[3, 0, 0, 0],
	                 [0, 4, 0, 0],
	                 [0, 0, 5, 0],
	                 [0, 0, 0, 1]])
	)
	function_domain = CoordinateSystem(coord_names=('x', 'y', 'z'), name='', coord_dtype=object)
	function_range = CoordinateSystem(coord_names=('i', 'j', 'k'), name='', coord_dtype=object)
	affine = array([[1.00000000000000, 0, 0, 0],
	       [0, 0, 1.00000000000000, 0],
	       [0, 1.00000000000000, 0, 0],
	       [0, 0, 0, 1.00000000000000]], dtype=object)

	    def __init__(self, function_domain, function_range, affine):
	        """ Initialize AffineTransform
	[…]
	        if not np.all(affine[-1] == bottom_row):
	>           raise ValueError('the homogeneous transform should have bottom=' + \
	                             f'row {repr(bottom_row)}')
	E           ValueError: the homogeneous transform should have bottom=row array([0, 0, 0, 1])

This change implements an adjustments to avoid the AffineTransform constructor to trip on the mismatch; as a bonus, the error message is extended to be a little bit more helpful.  Following up on this change and sympy's, a couple test outputs needed to be normalized.