### PR TITLE
build: Depend on numpy<2 for build

### DIFF
--- a/lib/fff_python_wrapper/fffpy.h
+++ b/lib/fff_python_wrapper/fffpy.h
@@ -32,14 +32,12 @@
    dso. (import_array() asks the pointer value to the python process)
 */
 /*
- * deal with differences in macro return result between Python 2 and 3
- * http://mail.scipy.org/pipermail/numpy-discussion/2010-December/054350.html
+ * IMP_OUT used to be a placeholder for selectin fffpy_import_array
+ * output type depending on the Python version, 2 or 3.  Contemporary
+ * numpy versions (>=2) dictate the return type of import_array, which
+ * is currently a void* (return NULL).
  */
-#if PY_MAJOR_VERSION >= 3
-typedef int IMP_OUT;
-#else
-typedef void IMP_OUT;
-#endif
+typedef void* IMP_OUT;
 
 extern IMP_OUT fffpy_import_array(void);
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = ["Development Status :: 3 - Alpha",
                "Programming Language :: Python :: 3.12",
                "Topic :: Scientific/Engineering"]
 dependencies = [
-    'numpy>=1.22',
+    'numpy>=1.22,<2',
     'scipy>=1.8',
     'nibabel>=3.2',
     'sympy>=1.9',
@@ -67,7 +67,7 @@ requires = [
   # From Numpy 1.25, Numpy is always backwards compatible for any given Python
   # version.  See:
   # https://numpy.org/doc/stable/release/1.25.0-notes.html#compiling-against-the-numpy-c-api-is-now-backwards-compatible-by-default
-  "numpy>=1.25; python_version > '3.8'",
+  "numpy>=1.25,<2; python_version > '3.8'",
   # SPEC0-minimum as of Dec 23, 2023
   "numpy==1.22; python_version <= '3.8'",
 ]


### PR DESCRIPTION
Numpy 2 broke builds, and there's no good way to test other issues while the build is failing. Supporting numpy 2 can be its own effort (#565).